### PR TITLE
Download jobs from MongoDB

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -21,8 +21,9 @@
 #include "FS.h"
 #include "Metrics.h"
 #include "Node.h"
-#include "Storage.h"
 #include "WorkerApplication.h"
+
+#include "Storage.h"
 
 BackendStat::BackendStat()
 {

--- a/src/collector/CMakeLists.txt
+++ b/src/collector/CMakeLists.txt
@@ -4,13 +4,13 @@ add_executable(mastermind-collector
     Storage.cpp Group.cpp Couple.cpp
     ConfigParser.cpp WorkerApplication.cpp CocaineHandlers.cpp
     FS.cpp FilterParser.cpp Backend.cpp
-    Filter.cpp Round.cpp Collector.cpp main.cpp)
+    Filter.cpp Round.cpp Collector.cpp Job.cpp main.cpp)
 
 target_link_libraries(mastermind-collector
     ${elliptics_cpp_LIBRARY} ${elliptics_client_LIBRARY}
     ${CocaineNative_LIBRARIES} ${Cocaine_LIBRARY}
     ${CURL_LIBRARIES} boost_system boost_thread msgpack rt
-     dispatch pthread_workqueue kqueue ev)
+     dispatch pthread_workqueue kqueue ev mongoclient)
 
 add_custom_target(tarball ALL
     COMMAND tar czf mastermind-collector.tar.gz mastermind-collector

--- a/src/collector/Collector.cpp
+++ b/src/collector/Collector.cpp
@@ -242,6 +242,7 @@ void Collector::execute_summary(void *arg)
     std::map<std::string, Node> & nodes = self.m_storage->get_nodes();
     std::map<int, Group> & groups = self.m_storage->get_groups();
     std::map<std::string, Couple> & couples = self.m_storage->get_couples();
+    std::map<int, Job> & jobs = self.m_storage->get_jobs();
 
     std::map<Backend::Status, int> backend_status;
     std::map<Group::Status, int> group_status;
@@ -271,6 +272,9 @@ void Collector::execute_summary(void *arg)
             ++fs_status[fsit->second.get_status()];
     }
 
+    for (auto it = jobs.begin(); it != jobs.end(); ++it)
+        ++job_status[it->second.get_status()];
+
     std::ostringstream ostr;
 
     ostr << "Storage contains:\n"
@@ -293,7 +297,11 @@ void Collector::execute_summary(void *arg)
         ostr << it->second << ' ' << Couple::status_str(it->first) << ' ';
     ostr << ")\n";
 
-    ostr << self.m_storage->get_namespaces().size() << " namespaces\n";
+    ostr << self.m_storage->get_namespaces().size() << " namespaces\n"
+         << jobs.size() << " jobs\n  ( ";
+    for (auto it = job_status.begin(); it != job_status.end(); ++it)
+        ostr << it->second << ' ' << Job::status_str(it->first) << ' ';
+    ostr << ")\n";
 
     ostr << "Round metrics:\n"
             "  Total time: " << MSEC(self.m_round_clock.total) << " ms\n"

--- a/src/collector/Collector.h
+++ b/src/collector/Collector.h
@@ -57,6 +57,8 @@ public:
 
     void finalize_round(Round *round);
 
+    void stop();
+
 public:
     void force_update(std::shared_ptr<on_force_update> handler);
     void get_snapshot(std::shared_ptr<on_get_snapshot> handler);

--- a/src/collector/Config.h
+++ b/src/collector/Config.h
@@ -20,7 +20,7 @@
 #define __106a1cb9_f3de_4358_86b0_b357cbd4855c
 
 #include <cstdint>
-#include <sstream>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -44,7 +44,9 @@ struct Config
         net_thread_num(3),
         io_thread_num(3),
         nonblocking_io_thread_num(3)
-    {}
+    {
+        metadata.options.connectTimeoutMS = 5000;
+    }
 
     uint64_t monitor_port;
     uint64_t wait_timeout;
@@ -57,27 +59,47 @@ struct Config
     uint64_t nonblocking_io_thread_num;
     std::vector<NodeInfo> nodes;
 
-    void print(std::ostringstream & ostr) const
-    {
-        ostr <<
-            "monitor_port: "                          << monitor_port << "\n"
-            "wait_timeout: "                          << wait_timeout << "\n"
-            "forbidden_dht_groups: "                  << forbidden_dht_groups << "\n"
-            "forbidden_unmatched_group_total_space: " << forbidden_unmatched_group_total_space << "\n"
-            "reserved_space: "                        << reserved_space << "\n"
-            "dnet_log_mask: "                         << dnet_log_mask << "\n"
-            "net_thread_num: "                        << net_thread_num << "\n"
-            "io_thread_num: "                         << io_thread_num << "\n"
-            "nonblocking_io_thread_num: "             << nonblocking_io_thread_num << "\n"
-            "nodes:\n";
-        for (const NodeInfo & node : nodes)
-            ostr << "  " << node.host << ':' << node.port << ':' << node.family << '\n';
-    }
+    struct {
+        std::string url;
+        struct {
+            uint64_t connectTimeoutMS;
+        } options;
+        struct {
+            std::string db;
+        } jobs;
+    } metadata;
 
     constexpr static const char *config_file        = "/etc/elliptics/mastermind.conf";
     constexpr static const char *log_file           = "/var/log/mastermind/mastermind-collector.log";
     constexpr static const char *elliptics_log_file = "/var/log/mastermind/elliptics-collector.log";
 };
+
+inline std::ostream & operator << (std::ostream & ostr, const Config & config)
+{
+    ostr <<
+        "monitor_port: "                          << config.monitor_port << "\n"
+        "wait_timeout: "                          << config.wait_timeout << "\n"
+        "forbidden_dht_groups: "                  << config.forbidden_dht_groups << "\n"
+        "forbidden_unmatched_group_total_space: " << config.forbidden_unmatched_group_total_space << "\n"
+        "reserved_space: "                        << config.reserved_space << "\n"
+        "dnet_log_mask: "                         << config.dnet_log_mask << "\n"
+        "net_thread_num: "                        << config.net_thread_num << "\n"
+        "io_thread_num: "                         << config.io_thread_num << "\n"
+        "nonblocking_io_thread_num: "             << config.nonblocking_io_thread_num << "\n"
+        "metadata: {\n"
+        "  url: "                                 << config.metadata.url << "\n"
+        "  options: {\n"
+        "    metadata_connect_timeout_ms: "       << config.metadata.options.connectTimeoutMS << "\n"
+        "  }\n"
+        "  jobs: {\n"
+        "    db: "                                << config.metadata.jobs.db << "\n"
+        "  }\n"
+        "}\n"
+        "nodes:\n";
+    for (const Config::NodeInfo & node : config.nodes)
+        ostr << "  " << node.host << ':' << node.port << ':' << node.family << '\n';
+    return ostr;
+}
 
 #endif
 

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -34,7 +34,13 @@ enum ConfigKey
     NonblockingIoThreadNum            = 0x100,
     Nodes                             = 0x200,
     MonitorPort                       = 0x400,
-    WaitTimeout                       = 0x800
+    WaitTimeout                       = 0x800,
+    Metadata                          = 0x1000,
+    Url                               = 0x2000,
+    Jobs                              = 0x4000,
+    Db                                = 0x8000,
+    Options                           = 0x10000,
+    ConnectTimeoutMS                  = 0x20000
 };
 
 Parser::Folder config_1[] = {
@@ -46,6 +52,7 @@ Parser::Folder config_1[] = {
     { "net_thread_num",                        0, NetThreadNum                      },
     { "io_thread_num",                         0, IoThreadNum                       },
     { "nonblocking_io_thread_num",             0, NonblockingIoThreadNum            },
+    { "metadata",                              0, Metadata                          },
     { NULL, 0, 0 }
 };
 
@@ -53,12 +60,22 @@ Parser::Folder config_2[] = {
     { "nodes",        Elliptics, Nodes       },
     { "monitor_port", Elliptics, MonitorPort },
     { "wait_timeout", Elliptics, WaitTimeout },
+    { "url",          Metadata,  Url         },
+    { "jobs",         Metadata,  Jobs        },
+    { "options",      Metadata,  Options     },
+    { NULL, 0, 0 }
+};
+
+Parser::Folder config_3[] = {
+    { "db",               Metadata|Jobs,    Db               },
+    { "connectTimeoutMS", Metadata|Options, ConnectTimeoutMS },
     { NULL, 0, 0 }
 };
 
 Parser::Folder *config_folders[] = {
     config_1,
-    config_2
+    config_2,
+    config_3
 };
 
 Parser::UIntInfo config_uint_info[] = {
@@ -71,6 +88,7 @@ Parser::UIntInfo config_uint_info[] = {
     { NetThreadNum,                      SET, offsetof(Config, net_thread_num)                        },
     { IoThreadNum,                       SET, offsetof(Config, io_thread_num)                         },
     { NonblockingIoThreadNum,            SET, offsetof(Config, nonblocking_io_thread_num)             },
+    { Metadata|Options|ConnectTimeoutMS, SET, offsetof(Config, metadata.options.connectTimeoutMS)     },
     { 0, 0, 0 }
 };
 
@@ -91,6 +109,10 @@ bool ConfigParser::String(const char* str, rapidjson::SizeType length, bool copy
 {
     if (m_keys == (Elliptics|Nodes|1) && m_array_depth == 2)
         m_current_node.host = std::string(str, length);
+    else if (m_keys == (Metadata|Url|1))
+        m_config.metadata.url = std::string(str, length);
+    else if (m_keys == (Metadata|Jobs|Db|1))
+        m_config.metadata.jobs.db = std::string(str, length);
     return true;
 }
 

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -47,6 +47,8 @@ class Couple
         BROKEN_GroupBROKEN,
         FROZEN_Frozen,
         FULL_Full,
+        SERVICE_ACTIVE_ServiceActive,
+        SERVICE_STALLED_ServiceStalled,
         OK_OK
     };
 
@@ -99,6 +101,9 @@ public:
 
     uint64_t get_update_status_duration() const
     { return m_update_status_duration; }
+
+private:
+    void account_job_in_status();
 
 private:
     std::string m_key;

--- a/src/collector/Discovery.cpp
+++ b/src/collector/Discovery.cpp
@@ -136,6 +136,12 @@ void Discovery::stop_mongo()
     mongo::client::shutdown();
 }
 
+void Discovery::stop_elliptics()
+{
+    m_session.reset();
+    m_node.reset();
+}
+
 void Discovery::stop_curl()
 {
     curl_global_cleanup();

--- a/src/collector/Discovery.h
+++ b/src/collector/Discovery.h
@@ -47,6 +47,7 @@ public:
     void resolve_nodes(Round & round);
 
     void stop_mongo();
+    void stop_elliptics();
     void stop_curl();
 
 private:

--- a/src/collector/Discovery.h
+++ b/src/collector/Discovery.h
@@ -26,6 +26,11 @@
 class Round;
 class WorkerApplication;
 
+// Discovery is responsible for maintaining elliptics connection,
+// root session, provides Storage with a list of nodes, and
+// performs global initialization and deinitialization of cURL,
+// elliptics, and MongoDB driver. Only a single instance of
+// this object is created.
 class Discovery
 {
 public:
@@ -34,11 +39,15 @@ public:
 
     int init_curl();
     int init_elliptics();
+    int init_mongo();
 
     ioremap::elliptics::session & get_session()
     { return *m_session; }
 
     void resolve_nodes(Round & round);
+
+    void stop_mongo();
+    void stop_curl();
 
 private:
     WorkerApplication & m_app;

--- a/src/collector/FS.cpp
+++ b/src/collector/FS.cpp
@@ -21,8 +21,9 @@
 #include "FS.h"
 #include "Metrics.h"
 #include "Node.h"
-#include "Storage.h"
 #include "WorkerApplication.h"
+
+#include "Storage.h"
 
 FS::FS(Node & node, uint64_t fsid)
     :

--- a/src/collector/Filter.h
+++ b/src/collector/Filter.h
@@ -31,7 +31,8 @@ struct Filter
         Namespace = 4,
         Node      = 8,
         Backend   = 0x10,
-        FS        = 0x20
+        FS        = 0x20,
+        Job       = 0x40
     };
 
     Filter()

--- a/src/collector/FilterParser.cpp
+++ b/src/collector/FilterParser.cpp
@@ -111,6 +111,8 @@ bool FilterParser::String(const char* str, rapidjson::SizeType length, bool copy
             m_filter.item_types |= Filter::Backend;
         else if (length == 2 && !std::strncmp(str, "fs", 2))
             m_filter.item_types |= Filter::FS;
+        else if (length == 3 && !std::strncmp(str, "job", 3))
+            m_filter.item_types |= Filter::Job;
         else
             return false;
     }

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "Job.h"
+
 class Backend;
 class Couple;
 class Filter;
@@ -46,6 +48,7 @@ class Group
         BAD_InconsistentCouple,
         BAD_DifferentMetadata,
         BAD_CoupleBAD,
+        BAD_NoActiveJob,
         MIGRATING_ServiceMigrating,
         RO_HaveROBackends,
         COUPLED_MetadataOK,
@@ -90,6 +93,11 @@ public:
 
     uint64_t get_total_space() const;
 
+    bool has_active_job() const;
+
+    // have_active_job() must be checked first
+    const Job & get_active_job() const;
+
     const std::string & get_namespace_name() const
     { return m_metadata.namespace_name; }
 
@@ -101,9 +109,6 @@ public:
 
     int get_version() const
     { return m_metadata.version; }
-
-    bool get_service_migrating() const
-    { return m_metadata.service.migrating; }
 
     void add_backend(Backend & backend);
 
@@ -121,6 +126,9 @@ public:
     uint64_t get_backend_update_time() const;
 
     void set_namespace(Namespace & ns);
+
+    void set_active_job(const Job & job);
+    void clear_active_job();
 
     void update_status(bool forbidden_dht);
     void set_coupled_status(bool ok, uint64_t timestamp);
@@ -179,11 +187,12 @@ private:
     bool m_metadata_parsed;
     uint64_t m_metadata_parse_duration;
 
-    // Pointers to a couple and a namespace of this group. If the information is
-    // unknown, e.g. metadata was not loaded, the values are set to nullptr.
-    // These objects shouldn't be modified directly but only used for status
-    // checks and by push_items().
+    // Pointers to a couple, active job, and a namespace of this group.
+    // If the information is unknown, e.g. metadata was not loaded,
+    // the values are set to nullptr. These objects shouldn't be modified
+    // directly but only used for status checks and by push_items().
     Couple *m_couple;
+    const Job *m_active_job;
     Namespace *m_namespace;
 
     std::string m_status_text;

--- a/src/collector/Job.cpp
+++ b/src/collector/Job.cpp
@@ -1,0 +1,168 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "Job.h"
+
+Job::Job(mongo::BSONObj & obj, uint64_t timestamp)
+    :
+    m_type(EMPTY),
+    m_status(NEW),
+    m_group_id(0),
+    m_timestamp(timestamp)
+{
+    for (mongo::BSONObj::iterator it = obj.begin(); it.more();) {
+        // BSONObj::iterator::next extracts a current element
+        // and increments the iterator
+        mongo::BSONElement element = it.next();
+        const char *field_name = element.fieldName();
+
+        if (!std::strcmp(field_name, "id")) {
+            m_id = element.String();
+        } else if (!std::strcmp(field_name, "group")) {
+            m_group_id = element.Int();
+        } else if (!std::strcmp(field_name, "status")) {
+            std::string str = element.String();
+
+            if (str == "new")
+                m_status = NEW;
+            else if (str == "executing")
+                m_status = EXECUTING;
+            else if (str == "broken")
+                m_status = BROKEN;
+            else if (str == "pending")
+                m_status = PENDING;
+            else if (str == "not_approved")
+                m_status = NOT_APPROVED;
+            else if (str == "cancelled")
+                m_status = CANCELLED;
+            else if (str == "completed")
+                m_status = COMPLETED;
+            else
+                throw std::runtime_error("Unknown job status " + str);
+
+        } else if (!std::strcmp(field_name, "type")) {
+            std::string str = element.String();
+
+            if (str == "move_job")
+                m_type = MOVE_JOB;
+            else if (str == "recover_dc_job")
+                m_type = RECOVER_DC_JOB;
+            else if (str == "couple_defrag_job")
+                m_type = COUPLE_DEFRAG_JOB;
+            else if (str == "restore_group_job")
+                m_type = RESTORE_GROUP_JOB;
+            else
+                throw std::runtime_error("Unknown job type " + str);
+        }
+    }
+
+    if (m_id.empty())
+        throw std::runtime_error("No job identifier");
+}
+
+void Job::merge(const Job & other, bool *have_newer)
+{
+    if (m_timestamp > other.m_timestamp) {
+        if (have_newer != nullptr)
+            *have_newer = true;
+        return;
+    }
+
+    if (m_timestamp == other.m_timestamp)
+        return;
+
+    m_id = other.m_id;
+    m_type = other.m_type;
+    m_status = other.m_status;
+    m_group_id = other.m_group_id;
+    m_timestamp = other.m_timestamp;
+}
+
+bool Job::operator == (const Job & other) const
+{
+    if (this == &other)
+        return true;
+
+    return std::tie(m_id, m_type, m_status, m_group_id) ==
+        std::tie(other.m_id, other.m_type, other.m_status, other.m_group_id);
+}
+
+void Job::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer)
+{
+    // JSON looks like this:
+    // {
+    //     "group": 23,
+    //     "id": "222fb6cc9cbe42aba4bbdfb6fcca9748",
+    //     "status": "NEW",
+    //     "type": "MOVE_JOB"
+    // }
+
+    writer.StartObject();
+    writer.Key("id");
+    writer.String(m_id.c_str());
+    writer.Key("type");
+    writer.String(type_str(m_type));
+    writer.Key("status");
+    writer.String(status_str(m_status));
+    writer.Key("group");
+    writer.Uint64(m_group_id);
+    writer.EndObject();
+}
+
+const char *Job::type_str(Type type)
+{
+    switch (type)
+    {
+    case EMPTY:
+        return "EMPTY";
+    case MOVE_JOB:
+        return "MOVE_JOB";
+    case RECOVER_DC_JOB:
+        return "RECOVER_DC_JOB";
+    case COUPLE_DEFRAG_JOB:
+        return "COUPLE_DEFRAG_JOB";
+    case RESTORE_GROUP_JOB:
+        return "RESTORE_GROUP_JOB";
+    }
+
+    // unreachable
+    return "UNKNOWN";
+}
+
+const char *Job::status_str(Status status)
+{
+    switch (status) {
+    case NEW:
+        return "NEW";
+    case NOT_APPROVED:
+        return "NOT_APPROVED";
+    case EXECUTING:
+        return "EXECUTING";
+    case PENDING:
+        return "PENDING";
+    case BROKEN:
+        return "BROKEN";
+    case COMPLETED:
+        return "COMPLETED";
+    case CANCELLED:
+        return "CANCELLED";
+    }
+
+    // unreachable
+    return "UNKNOWN";
+}

--- a/src/collector/Job.h
+++ b/src/collector/Job.h
@@ -1,0 +1,88 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#ifndef __19d1f67a_e4dc_4c98_9f61_5882632cb0a1
+#define __19d1f67a_e4dc_4c98_9f61_5882632cb0a1
+
+#include <mongo/client/dbclient.h>
+#include <rapidjson/writer.h>
+
+#include <string>
+
+class Job
+{
+public:
+    enum Type
+    {
+        EMPTY,
+        MOVE_JOB,
+        RECOVER_DC_JOB,
+        COUPLE_DEFRAG_JOB,
+        RESTORE_GROUP_JOB
+    };
+
+    enum Status
+    {
+        NEW,
+        NOT_APPROVED,
+        EXECUTING,
+        PENDING,
+        BROKEN,
+        COMPLETED,
+        CANCELLED
+    };
+
+    static const char *type_str(Type type);
+    static const char *status_str(Status status);
+
+public:
+    // timestamp is in nanoseconds
+    Job(mongo::BSONObj & obj, uint64_t timestamp);
+
+    const std::string & get_id() const
+    { return m_id; }
+
+    Type get_type() const
+    { return m_type; }
+
+    Status get_status() const
+    { return m_status; }
+
+    int get_group_id() const
+    { return m_group_id; }
+
+    void merge(const Job & other, bool *have_newer);
+
+    bool operator == (const Job & other) const;
+
+    bool operator != (const Job & other) const
+    { return !(*this == other); }
+
+    void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer);
+
+private:
+    std::string m_id;
+    Type m_type;
+    Status m_status;
+    int m_group_id;
+
+    uint64_t m_timestamp;
+};
+
+#endif
+

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -22,7 +22,10 @@
 #include "Round.h"
 #include "WorkerApplication.h"
 
+#include "Job.h"
+
 #include <errno.h>
+#include <mongo/client/dbclient.h>
 #include <sys/epoll.h>
 #include <fcntl.h>
 
@@ -145,10 +148,97 @@ void Round::start()
             (m_type == REGULAR) ? "regular" : (m_type == FORCED_FULL) ? "forced full" : "forced partial",
             (m_type == FORCED_PARTIAL ? m_entries.nodes.size() : m_storage->get_nodes().size()));
 
-    dispatch_async_f(m_queue, this, &Round::step2_curl_download);
+    dispatch_async_f(m_queue, this, &Round::step2_1_jobs);
+    dispatch_async_f(m_queue, this, &Round::step2_2_curl_download);
 }
 
-void Round::step2_curl_download(void *arg)
+void Round::step2_1_jobs(void *arg)
+{
+    Round & self = *static_cast<Round*>(arg);
+
+    Stopwatch watch(self.m_clock.jobs_database);
+
+    try {
+        const Config & config = self.get_app().get_config();
+
+        if (config.metadata.url.empty() || config.metadata.jobs.db.empty()) {
+            BH_LOG(self.get_app().get_logger(), DNET_LOG_WARNING,
+                    "Not connecting to jobs database because it was not configured");
+            return;
+        }
+
+        std::string errmsg;
+        mongo::ConnectionString cs = mongo::ConnectionString::parse(config.metadata.url, errmsg);
+        if (!cs.isValid()) {
+            BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                    "Mongo client ConnectionString error: %s", errmsg.c_str());
+            return;
+        }
+
+        std::unique_ptr<mongo::DBClientReplicaSet> conn((mongo::DBClientReplicaSet *) cs.connect(
+                errmsg, double(config.metadata.options.connectTimeoutMS) / 1000.0));
+        if (conn == nullptr) {
+            BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                    "Connection failed: %s", errmsg.c_str());
+            return;
+        }
+
+        mongo::BSONObjBuilder builder;
+        builder.append("id", 1);
+        builder.append("status", 1);
+        builder.append("group", 1);
+        builder.append("type", 1);
+        mongo::BSONObj fields = builder.obj();
+
+        std::unique_ptr<mongo::DBClientCursor> cursor(conn->query(config.metadata.jobs.db + ".jobs",
+                MONGO_QUERY("status" << mongo::NE << "completed"
+                         << "status" << mongo::NE << "cancelled").readPref(
+                             mongo::ReadPreference_PrimaryOnly, mongo::BSONArray()),
+                0, 0, &fields).release());
+
+        uint64_t ts = 0;
+        clock_get(ts);
+        std::vector<Job> jobs;
+        size_t count = 0;
+
+        while (cursor->more()) {
+            mongo::BSONObj obj = cursor->next();
+            try {
+                Job job(obj, ts);
+                jobs.emplace_back(std::move(job));
+            } catch (const mongo::MsgAssertionException & e) {
+                BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                        "Failed to parse database record: %s\nBSON object: %s",
+                        e.what(), obj.jsonString(mongo::Strict, 1));
+            } catch (const std::exception & e) {
+                BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                        "Failed to initialize job: %s\nBSON object: %s",
+                        e.what(), obj.jsonString(mongo::Strict, 1));
+            } catch (...) {
+                BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                        "Initializing job: Unknown exception thrown");
+            }
+            ++count;
+        }
+
+        BH_LOG(self.get_app().get_logger(), DNET_LOG_INFO,
+                "Successfully processed %lu of %lu active jobs", jobs.size(), count);
+
+        // self.m_storage->save_new_jobs(std::move(jobs), ts);
+
+    } catch (const mongo::DBException & e) {
+        BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                "MongoDB thrown exception: %s", e.what());
+    } catch (const std::exception & e) {
+        BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                "Exception thrown while connecting to jobs database: %s", e.what());
+    } catch (...) {
+        BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
+                "Unknown exception thrown while connecting to jobs database");
+    }
+}
+
+void Round::step2_2_curl_download(void *arg)
 {
     Round & self = *static_cast<Round*>(arg);
 
@@ -157,7 +247,7 @@ void Round::step2_curl_download(void *arg)
 
     self.perform_download();
 
-    clock_start(self.m_clock.finish_monitor_stats);
+    clock_start(self.m_clock.finish_monitor_stats_and_jobs);
     dispatch_barrier_async_f(self.m_queue, &self, &Round::step3_prepare_metadata_download);
 }
 
@@ -165,9 +255,10 @@ void Round::step3_prepare_metadata_download(void *arg)
 {
     Round & self = *static_cast<Round*>(arg);
 
-    clock_stop(self.m_clock.finish_monitor_stats);
+    clock_stop(self.m_clock.finish_monitor_stats_and_jobs);
 
     self.m_storage->update_group_structure();
+    // self.m_storage->process_new_jobs();
 
     self.m_nr_groups = (self.m_type != FORCED_PARTIAL
             ? self.m_storage->get_groups().size()

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -224,7 +224,7 @@ void Round::step2_1_jobs(void *arg)
         BH_LOG(self.get_app().get_logger(), DNET_LOG_INFO,
                 "Successfully processed %lu of %lu active jobs", jobs.size(), count);
 
-        // self.m_storage->save_new_jobs(std::move(jobs), ts);
+        self.m_storage->save_new_jobs(std::move(jobs), ts);
 
     } catch (const mongo::DBException & e) {
         BH_LOG(self.get_app().get_logger(), DNET_LOG_ERROR,
@@ -258,7 +258,7 @@ void Round::step3_prepare_metadata_download(void *arg)
     clock_stop(self.m_clock.finish_monitor_stats_and_jobs);
 
     self.m_storage->update_group_structure();
-    // self.m_storage->process_new_jobs();
+    self.m_storage->process_new_jobs();
 
     self.m_nr_groups = (self.m_type != FORCED_PARTIAL
             ? self.m_storage->get_groups().size()

--- a/src/collector/Round.h
+++ b/src/collector/Round.h
@@ -88,7 +88,8 @@ public:
     void start();
 
 private:
-    static void step2_curl_download(void *arg);
+    static void step2_1_jobs(void *arg);
+    static void step2_2_curl_download(void *arg);
     static void step3_prepare_metadata_download(void *arg);
     static void step4_perform_update(void *arg);
 
@@ -121,8 +122,9 @@ public:
         ClockStat & operator = (const ClockStat & other);
 
         uint64_t total;
+        uint64_t jobs_database;
         uint64_t perform_download;
-        uint64_t finish_monitor_stats;
+        uint64_t finish_monitor_stats_and_jobs;
         uint64_t metadata_download;
         uint64_t storage_update;
         uint64_t merge_time;
@@ -150,7 +152,6 @@ private:
 
     dispatch_queue_t m_queue;
 
-    int m_http_port;
     int m_epollfd;
     CURLM *m_curl_handle;
     long m_timeout_ms;

--- a/src/collector/WorkerApplication.cpp
+++ b/src/collector/WorkerApplication.cpp
@@ -33,7 +33,8 @@ WorkerApplication::WorkerApplication()
     :
     m_logger(nullptr),
     m_elliptics_logger(nullptr),
-    m_collector(*this)
+    m_collector(*this),
+    m_initialized(false)
 {}
 
 WorkerApplication::WorkerApplication(cocaine::framework::dispatch_t & d)
@@ -48,6 +49,11 @@ WorkerApplication::WorkerApplication(cocaine::framework::dispatch_t & d)
     d.on<on_refresh>("refresh", *this);
 
     start();
+}
+
+WorkerApplication::~WorkerApplication()
+{
+    stop();
 }
 
 void WorkerApplication::init()
@@ -65,6 +71,17 @@ void WorkerApplication::init()
 
     if (m_collector.init())
         throw std::runtime_error("failed to initialize collector");
+
+    m_initialized = true;
+}
+
+void WorkerApplication::stop()
+{
+    // invoke stop() exactly one time
+    if (m_initialized) {
+        m_collector.stop();
+        m_initialized = false;
+    }
 }
 
 void WorkerApplication::start()

--- a/src/collector/WorkerApplication.cpp
+++ b/src/collector/WorkerApplication.cpp
@@ -16,10 +16,11 @@
    License along with Mastermind.
 */
 
-#include "Storage.h"
 #include "CocaineHandlers.h"
 #include "ConfigParser.h"
 #include "WorkerApplication.h"
+
+#include "Storage.h"
 
 #include <elliptics/logger.hpp>
 #include <rapidjson/reader.h>
@@ -59,10 +60,8 @@ void WorkerApplication::init()
     m_elliptics_logger.reset(new ioremap::elliptics::file_logger(
             Config::elliptics_log_file, ioremap::elliptics::log_level(m_config.dnet_log_mask)));
 
-    std::ostringstream ostr;
-    ostr << "Loaded config from " << Config::config_file << ":\n";
-    m_config.print(ostr);
-    BH_LOG(get_logger(), DNET_LOG_INFO, "%s", ostr.str().c_str());
+    const char *config_file = Config::config_file;
+    BH_LOG(get_logger(), DNET_LOG_INFO, "Loaded config from %s:\n%s", config_file, m_config);
 
     if (m_collector.init())
         throw std::runtime_error("failed to initialize collector");

--- a/src/collector/WorkerApplication.h
+++ b/src/collector/WorkerApplication.h
@@ -32,9 +32,11 @@ class WorkerApplication
 public:
     WorkerApplication();
     WorkerApplication(cocaine::framework::dispatch_t & d);
+    ~WorkerApplication();
 
     void init();
     void start();
+    void stop();
 
     ioremap::elliptics::logger_base & get_logger()
     { return *m_logger; }
@@ -60,6 +62,8 @@ private:
 
     Config m_config;
     Collector m_collector;
+
+    bool m_initialized;
 };
 
 #endif


### PR DESCRIPTION
When a user schedules a mastermind task to move a group from one node to  another, run defragmentation, and so on, a special item 'Job' is created. It is assigned to a specific group, and has type, status, and unique identifier. Information about the job is saved in MongoDB collection 'jobs'.
Database name is specified in mastermind.conf at 'metadata/jobs/db'. Job identifier and status are also written in group's metakey.

Given a BAD couple we want to see if it is currently under maintenance. For this reason statuses SERVICE_ACTIVE and SERVICE_STALLED were introduced. The couple turns into SERVICE_ACTIVE when one of its groups has an active job (we are not interested in completed or cancelled jobs) of type 'move' or 'restore' which is newly created or currently executing. Otherwise, we set couple's status to SERVICE_STALLED.

This set of commits implements described features.
