### PR TITLE
Move group history records from metaelliptics to mongo db

### DIFF
--- a/src/cocaine-app/__init__.py
+++ b/src/cocaine-app/__init__.py
@@ -25,6 +25,7 @@ logger = logging.getLogger('mm.init')
 import balancer
 import balancelogicadapter
 from db.mongo.pool import MongoReplicaSetClient
+import history
 import infrastructure
 import jobs
 import minions
@@ -212,9 +213,9 @@ def register_handle_wne(h):
     return wrapper
 
 
-def init_infrastructure(jf):
+def init_infrastructure(jf, ghf):
     infstruct = infrastructure.infrastructure
-    infstruct.init(n, jf)
+    infstruct.init(n, jf, ghf)
     register_handle(infstruct.shutdown_node_cmd)
     register_handle(infstruct.start_node_cmd)
     register_handle(infstruct.disable_node_backend_cmd)
@@ -274,6 +275,11 @@ def init_job_finder():
     return jf
 
 
+def init_group_history_finder():
+    ghf = history.GroupHistoryFinder(meta_db)
+    return ghf
+
+
 def init_job_processor(jf, minions, niu):
     if jf is None:
         logger.error(
@@ -299,7 +305,8 @@ def init_manual_locker(manual_locker):
 
 
 jf = init_job_finder()
-io = init_infrastructure(jf)
+ghf = init_group_history_finder()
+io = init_infrastructure(jf, ghf)
 niu = init_node_info_updater(jf)
 b.niu = niu
 b.start()

--- a/src/cocaine-app/balancer.py
+++ b/src/cocaine-app/balancer.py
@@ -461,12 +461,12 @@ class Balancer(object):
     @h.concurrent_handler
     def get_group_history(self, request):
         group = int(request[0])
-        group_history = {}
 
         if self.infrastructure:
             group_history = self.infrastructure.get_group_history(group)
+            return group_history.dump()
 
-        return group_history
+        raise ValueError('History for group {} is not found'.format(group))
 
     NODE_BACKEND_RE = re.compile('(.+):(\d+)/(\d+)')
 

--- a/src/cocaine-app/db/mongo/__init__.py
+++ b/src/cocaine-app/db/mongo/__init__.py
@@ -5,6 +5,8 @@ logger = logging.getLogger('mm.mongo')
 
 class MongoObject(object):
 
+    PRIMARY_ID_KEY = 'id'
+
     def __init__(self, *args, **kwargs):
         super(MongoObject, self).__init__(*args, **kwargs)
         self._dirty = False
@@ -18,7 +20,7 @@ class MongoObject(object):
             logger.debug('Object with id {0} has no _dirty flag set'.format(self.id))
             return
 
-        res = self.collection.update({'id': self.id}, self.dump(), upsert=True)
+        res = self.collection.update({self.PRIMARY_ID_KEY: self.id}, self.dump(), upsert=True)
         if res['ok'] != 1:
             logger.error('Unexpected mongo response: {0}, saving object {1}'.format(res, self.dump()))
             raise RuntimeError('Mongo operation result: {0}'.format(res['ok']))

--- a/src/cocaine-app/db/mongo/pool.py
+++ b/src/cocaine-app/db/mongo/pool.py
@@ -185,3 +185,26 @@ class Collection(OriginalCollection):
             (self.database.connection.name, self.database.name, self.name, 'find_one', str(args), str(kwargs), slave_read_status(kwargs))
         __set_request_message__(request_message)
         return super(Collection, self).find_one(*args, **kwargs)
+
+    def list(self, **kwargs):
+        """
+        Returns mongo query cursor
+
+        The cursor can be further parametrized by additional filteres,
+        query parameters, etc.
+        """
+        params = {}
+
+        for k, v in kwargs.iteritems():
+            if v is None:
+                continue
+            params.update(self.condition(k, v))
+
+        return self.find(params)
+
+    @staticmethod
+    def condition(field_name, field_val):
+        if isinstance(field_val, (list, tuple)):
+            return {field_name: {'$in': list(field_val)}}
+        else:
+            return {field_name: field_val}

--- a/src/cocaine-app/fake_inventory.py
+++ b/src/cocaine-app/fake_inventory.py
@@ -89,6 +89,7 @@ def node_reconfigure(host, port, family):
     '''
     return None
 
+
 def set_net_monitoring_downtime(host):
     '''
     If your infrastructure monitors network activity, it can cause alerts
@@ -99,6 +100,7 @@ def set_net_monitoring_downtime(host):
     is already set.
     '''
     return None
+
 
 def remove_net_monitoring_downtime(host):
     '''

--- a/src/cocaine-app/fake_inventory.py
+++ b/src/cocaine-app/fake_inventory.py
@@ -105,3 +105,36 @@ def remove_net_monitoring_downtime(host):
     See "set_net_monitoring_downtime" doc string.
     '''
     return None
+
+
+def get_host_ip_addresses(hostname):
+    '''
+    Resolves hostname to ip(v6) addresses
+
+    Mastermind will preferably use address with a family corresponding
+    to elliptics client connection settings.
+
+    Returns:
+        {
+            socket.AF_INET: [
+                '1.2.3.4',
+                '5.6.7.8',
+            ],
+            socket.AF_INET6: [
+                '2001:db8:0:1',
+            ]
+        }
+    '''
+    ip_addresses = {}
+    host, port, family, socktype = hostname, None, socket.AF_UNSPEC, socket.SOL_TCP
+    records = socket.getaddrinfo(host, port, family, socktype)
+    for record in records:
+        # record format is (family, socktype, proto, canonname, sockaddr),
+        # sockaddr format depends on family of the socket:
+        # socket.AF_INET - (address, port),
+        # socket.AF_INET6 - (address, port, flow info, scope id).
+        # See docs for more info: https://docs.python.org/2/library/socket.html#socket.getaddrinfo
+        family, sockaddr = record[0], record[4]
+        ip_address = sockaddr[0]
+        ip_addresses.setdefault(family, []).append(ip_address)
+    return ip_addresses

--- a/src/cocaine-app/history.py
+++ b/src/cocaine-app/history.py
@@ -1,0 +1,373 @@
+import logging
+
+from config import config
+from db.mongo import MongoObject
+from db.mongo.pool import Collection
+
+
+logger = logging.getLogger('mm.infrastructure')
+
+
+class GroupHistory(MongoObject):
+    """
+    Group's complete history
+
+    History objects can provide two types of changes that were recorded by mastermind:
+        - group's affiliation with a couple;
+        - node backends that were a part of group at any time.
+
+    Every state record contains timestamp and record type which represents a reason
+    why the state was changed so that process of group evolution could be easily traced.
+
+    Attributes:
+        group_id - id of a group to which history belongs;
+        couples - iterable of GroupCoupleRecord which represents the points in time
+            when group changed its affiliation with a couple;
+        nodes - iterable of GroupNodeBackendsSetRecord which represents changes
+            of underlying node backends set.
+    """
+
+    GROUP_ID = 'group_id'
+    COUPLES = 'couples'
+    NODES = 'nodes'
+
+    PRIMARY_ID_KEY = GROUP_ID
+
+    def __init__(self, **init_params):
+        super(GroupHistory, self).__init__()
+
+        self.group_id = init_params.get(self.GROUP_ID, None)
+        self.couples = [
+            GroupCoupleRecord(**record)
+            for record in init_params.get(self.COUPLES, [])
+        ]
+        self.nodes = [
+            GroupNodeBackendsSetRecord(**record)
+            for record in init_params.get(self.NODES, [])
+        ]
+
+    @property
+    def id(self):
+        return self.group_id
+
+    @classmethod
+    def new(cls, **kwargs):
+        super(GroupHistory, cls).new(**kwargs)
+        group_history = cls(**kwargs)
+        group_history._dirty = True
+        return group_history
+
+    def dump(self):
+        return {
+            'group_id': self.group_id,
+            'couples': [cr.dump() for cr in self.couples],
+            'nodes': [nbsr.dump() for nbsr in self.nodes],
+        }
+
+
+class GroupStateRecord(object):
+    """
+    Base class for any group history state record
+
+    Every state record should contain following attributes:
+        timestamp - timestamp of record creation;
+        type - one of the following:
+            * automatic:
+                such records are created by periodic tasks inside mastermind worker
+                when it decides that most recent group record does not
+                correspond to group's current state;
+            * manual:
+                manual records are created with one-time API calls, e.g. via mastermind
+                util, to make deliberate changes to group history record;
+            * job:
+                job records are created by jobs mechanism to deliberately change group
+                history record.
+
+    """
+    HISTORY_RECORD_AUTOMATIC = 'automatic'
+    HISTORY_RECORD_MANUAL = 'manual'
+    HISTORY_RECORD_JOB = 'job'
+
+    def __init__(self, timestamp=None, type=HISTORY_RECORD_AUTOMATIC):
+        self.timestamp = timestamp
+        self.type = type
+
+
+class GroupNodeBackendsSet(list):
+    """
+    List of unique GroupNodeBackendRecord objects
+
+    Used as a set for GroupNodeBackendsSetRecord.
+    """
+    def __init__(self, *args, **kwargs):
+        super(GroupNodeBackendsSet, self).__init__(*args, **kwargs)
+        if len(self) != len(set(*args, **kwargs)):
+            raise ValueError('Node backends set should contain only unique elements')
+
+    def append(self, item):
+        if item in self:
+            raise ValueError('Node backend {} is already in node backends set'.format(item))
+        super(GroupNodeBackendsSet, self).append(item)
+
+    def extend(self, items):
+        for item in items:
+            self.append(item)
+
+    def insert(self, idx, item):
+        if item in self:
+            raise ValueError('Node backend {} is already in node backends set'.format(item))
+        super(GroupNodeBackendsSet, self).insert(idx, item)
+
+    def __setitem__(self, idx, item):
+        raise NotImplementedError('GroupNodeBackends set does not support __setitem__ method')
+
+    def __setslice__(self, i, j, items):
+        raise NotImplementedError('GroupNodeBackends set does not support __setslice__ method')
+
+    def __getslice__(self, i, j):
+        return GroupNodeBackendsSet(super(GroupNodeBackendsSet, self).__getslice__(i, j))
+
+    def __add__(self, other):
+        obj = GroupNodeBackendsSet()
+        for nb in self:
+            obj.append(nb)
+        for nb in other:
+            obj.append(nb)
+        return obj
+
+
+class GroupNodeBackendsSetRecord(GroupStateRecord):
+    """
+    Record that represents group's node backend set recorded at certain time
+
+    Attributes:
+        set - iterable of GroupNodeBackendRecord objects
+        timestamp - timestamp of record creation
+        type - type of the record, GroupStateRecord.HISTORY_*
+    """
+    def __init__(self, set, timestamp=None, type=GroupStateRecord.HISTORY_RECORD_AUTOMATIC):
+        super(GroupNodeBackendsSetRecord, self).__init__(timestamp, type)
+        self.set = GroupNodeBackendsSet(
+            nbr if isinstance(nbr, GroupNodeBackendRecord) else GroupNodeBackendRecord(**nbr)
+            for nbr in set
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __eq__(self, other):
+        return set(nbr for nbr in self.set) == set(nbr for nbr in other.set)
+
+    def dump(self):
+        return {
+            'set': [nbr.dump() for nbr in self.set],
+            'timestamp': self.timestamp,
+            'type': self.type,
+        }
+
+    def __repr__(self):
+        return '<GroupNodeBackendsSetRecord: set {set}, timestamp {ts}, type {type}>'.format(
+            set=[repr(nbr) for nbr in self.set],
+            ts=self.timestamp,
+            type=self.type
+        )
+
+
+class GroupNodeBackendRecord(object):
+    """
+    Represents node backend that was noted as a part of a group at a certain time
+
+    A set of such objects is united under a single GroupNodeBackendsSet object,
+    which takes part in GroupNodeBackendsSetRecord along with record's timestamp and type.
+    """
+    def __init__(self, hostname, port, family, backend_id, path):
+        self.hostname = hostname
+        self.port = port
+        self.family = family
+        self.backend_id = backend_id
+        self.path = path
+
+    def __hash__(self):
+        return hash((self.hostname, self.port, self.family, self.backend_id, self.path))
+
+    def __eq__(self, other):
+        return (self.hostname == other.hostname and
+                self.port == other.port and
+                self.family == other.family and
+                self.backend_id == other.backend_id and
+                self.path == other.path)
+
+    def dump(self):
+        return {
+            'hostname': self.hostname,
+            'port': self.port,
+            'family': self.family,
+            'backend_id': self.backend_id,
+            'path': self.path,
+        }
+
+    def __repr__(self):
+        return (
+            '<GroupNodeBackendRecord: '
+            'hostname={hostname}, '
+            'port={port}, '
+            'family={family}, '
+            'backend_id={backend_id}, '
+            'path={path}>'.format(
+                hostname=self.hostname,
+                port=self.port,
+                family=self.family,
+                backend_id=self.backend_id,
+                path=self.path
+            )
+        )
+
+
+class GroupCoupleRecord(GroupStateRecord):
+    """
+    Record that represents group's affiliation with couple
+
+    Attributes:
+        couple - iterable of integer group ids
+        timestamp - timestamp of record creation
+        type - type of the record, GroupStateRecord.HISTORY_*
+    """
+    def __init__(self, couple, timestamp=None, type=GroupStateRecord.HISTORY_RECORD_AUTOMATIC):
+        super(GroupCoupleRecord, self).__init__(timestamp, type)
+        self.couple = couple
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __eq__(self, other):
+        return set(self.couple) == set(other.couple)
+
+    def dump(self):
+        return {
+            'couple': self.couple,
+            'type': self.type,
+            'timestamp': self.timestamp,
+        }
+
+    def __repr__(self):
+        return '<GroupCoupleRecord: couple {couple}, timestamp {ts}, type {type}>'.format(
+            couple=self.couple,
+            ts=self.timestamp,
+            type=self.type
+        )
+
+
+class GroupHistoryNotFoundError(Exception):
+    pass
+
+
+class GroupHistoryFinder(object):
+
+    def __init__(self, db):
+        self.collection = Collection(db[config['metadata']['history']['db']], 'history')
+
+    def _get_group_history(self, group_id):
+        group_history_list = (
+            self.collection
+            .list(group_id=group_id)
+            .limit(1)
+        )
+        if not group_history_list.count():
+            raise GroupHistoryNotFoundError(
+                'Group history for group {} is not found'.format(group_id)
+            )
+        group_history = GroupHistory.new(**group_history_list[0])
+        group_history.collection = self.collection
+        return group_history
+
+    def group_history(self, group_id):
+        try:
+            return self._get_group_history(group_id)
+        except GroupHistoryNotFoundError:
+            return None
+        except Exception:
+            logger.exception('History finder failed')
+            return None
+
+    def groups_history(self, ids=None):
+        group_histories = [
+            GroupHistory(**gh)
+            for gh in self.collection.list(group_id=ids)
+        ]
+        for gh in group_histories:
+            gh.collection = self.collection
+            gh._dirty = False
+        return group_histories
+
+    def search_by_node_backend(self,
+                               hostname=None,
+                               port=None,
+                               family=None,
+                               backend_id=None,
+                               path=None):
+        node_backend_pattern = {}
+        if hostname:
+            node_backend_pattern['hostname'] = hostname
+        if port:
+            node_backend_pattern['port'] = port
+        if family:
+            node_backend_pattern['family'] = family
+        if backend_id:
+            node_backend_pattern['backend_id'] = backend_id
+        if path:
+            if not path.startswith('^'):
+                path = '^' + path
+            if not path.endswith('$'):
+                path = path + '$'
+            path = path.replace('*', '.*')
+            node_backend_pattern['path'] = {'$regex': path}
+
+        if not node_backend_pattern:
+            raise ValueError('Filter parameters for node backends should be supplied')
+
+        group_histories_records = self.collection.find({
+            'nodes.set': {
+                '$elemMatch': node_backend_pattern
+            }
+        })
+
+        ghs = []
+        for group_history_record in group_histories_records:
+            gh = GroupHistory(**group_history_record)
+            gh.collection = self.collection
+            ghs.append(gh)
+        return ghs
+
+    def search_by_history_record(self,
+                                 start_ts=None,
+                                 finish_ts=None,
+                                 type=None):
+        record_pattern = {}
+        if type:
+            record_pattern.update(Collection.condition('type', type))
+        if start_ts or finish_ts:
+            timestamp_pattern = {}
+            if start_ts:
+                timestamp_pattern['$gte'] = start_ts
+            if finish_ts:
+                timestamp_pattern['$lt'] = finish_ts
+            record_pattern['timestamp'] = timestamp_pattern
+        or_pattern = {'$or': [
+            {
+                'couples': {
+                    '$elemMatch': record_pattern,
+                }
+            },
+            {
+                'nodes': {
+                    '$elemMatch': record_pattern,
+                }
+            },
+        ]}
+
+        ghs = []
+        for group_history_record in self.collection.find(or_pattern):
+            gh = GroupHistory(**group_history_record)
+            gh.collection = self.collection
+            ghs.append(gh)
+        return ghs

--- a/src/cocaine-app/infrastructure_cache.py
+++ b/src/cocaine-app/infrastructure_cache.py
@@ -1,7 +1,6 @@
 import logging
 import socket
 import time
-import traceback
 
 import msgpack
 

--- a/src/cocaine-app/infrastructure_cache.py
+++ b/src/cocaine-app/infrastructure_cache.py
@@ -17,6 +17,13 @@ logger = logging.getLogger('mm.infrastructure')
 
 
 class InfrastructureCache(object):
+
+    DEFAULT_FAMILY = config['elliptics']['nodes'][0][2]
+    FAMILIES_FALLBACK_PRIO = {
+        socket.AF_INET6: (socket.AF_INET,),
+        socket.AF_INET: (),
+    }
+
     def init(self, meta_session, tq):
         self.meta_session = meta_session
         self.__tq = tq
@@ -31,6 +38,14 @@ class InfrastructureCache(object):
 
         self.hosttree_cache = HostTreeCacheItem(self.meta_session,
             keys.MM_HOSTTREE_CACHE_IDX, keys.MM_HOSTTREE_CACHE_HOST, self.__tq)
+
+        self.ip_addresses_cache = IpAddressesCacheItem(
+            meta_session=self.meta_session,
+            idx_key=keys.MM_IPADDRESSES_CACHE_IDX,
+            key_tpl=keys.MM_IPADDRESSES_CACHE_HOST,
+            task_queue=self.__tq
+        )
+
         self.hosttree_cache._sync_cache()
 
     @staticmethod
@@ -51,6 +66,21 @@ class InfrastructureCache(object):
     def get_host_tree(self, hostname, strict=True):
         return self.strictable(self.hosttree_cache, hostname, strict)
 
+    def get_ip_address_by_host(self, host, strict=True):
+        addresses = self.strictable(self.ip_addresses_cache, host, strict)
+
+        if addresses.get(self.DEFAULT_FAMILY, None):
+            return addresses[self.DEFAULT_FAMILY][0]
+
+        for family in self.FAMILIES_FALLBACK_PRIO.get(self.DEFAULT_FAMILY, []):
+            if addresses.get(family, None):
+                return addresses[family][0]
+
+        if strict:
+            raise ValueError('Host {} cannot be resolved to ip address'.format(host))
+
+        return None
+
 
 cache = InfrastructureCache()
 
@@ -68,10 +98,10 @@ class InfrastructureCacheManager(object):
 
 class CacheItem(object):
 
-    def __init__(self, meta_session, idx_key, key_key, tq):
+    def __init__(self, meta_session, idx_key, key_tpl, task_queue):
         self.meta_session = meta_session.clone()
-        self.idx = indexes.SecondaryIndex(idx_key, key_key, self.meta_session)
-        self.__tq = tq
+        self.idx = indexes.SecondaryIndex(idx_key, key_tpl, self.meta_session)
+        self.__tq = task_queue
         self.cache = {}
 
         for attr in ['taskname', 'logprefix', 'sync_period', 'key_expire_time']:
@@ -178,3 +208,17 @@ class HostTreeCacheItem(CacheItem):
 
     def get_value(self, key):
         return inventory.get_host_tree(key)
+
+
+class IpAddressesCacheItem(CacheItem):
+    def __init__(self, *args, **kwargs):
+        self.taskname = 'infrastructure_ipaddresses_cache_sync'
+        self.logprefix = 'ipaddresses cache: '
+        self.sync_period = config.get('infrastructure_ipaddresses_cache_update_period', 600)
+        self.key_expire_time = config.get('infrastructure_ipaddresses_cache_valid_time', 604800)
+        super(IpAddressesCacheItem, self).__init__(*args, **kwargs)
+
+        self.fallback_value = {}
+
+    def get_value(self, key):
+        return inventory.get_host_ip_addresses(key)

--- a/src/cocaine-app/infrastructure_cache.py
+++ b/src/cocaine-app/infrastructure_cache.py
@@ -66,7 +66,11 @@ class InfrastructureCache(object):
         return self.strictable(self.hosttree_cache, hostname, strict)
 
     def get_ip_address_by_host(self, host, strict=True):
-        addresses = self.strictable(self.ip_addresses_cache, host, strict)
+        addresses = self.strictable(
+            cache=self.ip_addresses_cache,
+            key=host,
+            strict=strict
+        )
 
         if addresses.get(self.DEFAULT_FAMILY, None):
             return addresses[self.DEFAULT_FAMILY][0]

--- a/src/cocaine-app/inventory.py
+++ b/src/cocaine-app/inventory.py
@@ -16,3 +16,4 @@ get_balancer_node_types = inv.get_balancer_node_types
 get_dc_node_type = inv.get_dc_node_type
 set_net_monitoring_downtime = inv.set_net_monitoring_downtime
 remove_net_monitoring_downtime = inv.remove_net_monitoring_downtime
+get_host_ip_addresses = inv.get_host_ip_addresses

--- a/src/cocaine-app/keys.py
+++ b/src/cocaine-app/keys.py
@@ -16,6 +16,9 @@ MM_HOSTNAME_CACHE_HOST = 'mastermind:hostname_cache_%s'
 MM_HOSTTREE_CACHE_IDX = 'mastermind:hosttree_cache'
 MM_HOSTTREE_CACHE_HOST = 'mastermind:hosttree_cache_%s'
 
+MM_IPADDRESSES_CACHE_IDX = 'mastermind:ipaddresses_cache'
+MM_IPADDRESSES_CACHE_HOST = 'mastermind:ipaddresses_cache_%s'
+
 MM_NAMESPACE_SETTINGS_IDX = 'mastermind:ns_settings_idx'
 MM_NAMESPACE_SETTINGS_KEY_TPL = 'mastermind:ns_setttings:%s'
 

--- a/src/cocaine-app/planner.py
+++ b/src/cocaine-app/planner.py
@@ -857,9 +857,12 @@ class Planner(object):
         job_params['src_group'] = src_group.group_id
 
         if use_uncoupled_group:
-            nodes_set = infrastructure.get_group_history(group.group_id)['nodes'][-1]['set']
+            nodes_set = infrastructure.get_group_history(group.group_id).nodes[-1].set
             if len(nodes_set) == 1:
-                uncoupled_groups = self.find_uncoupled_groups(group, nodes_set[0][0])
+                uncoupled_groups = self.find_uncoupled_groups(
+                    group=group,
+                    host_addr=cache.get_ip_address_by_host(nodes_set[0].hostname)
+                )
             else:
                 uncoupled_groups = self.select_uncoupled_groups(group)
             job_params['uncoupled_group'] = uncoupled_groups[0].group_id

--- a/src/mastermind
+++ b/src/mastermind
@@ -356,28 +356,22 @@ def group_search_by_path(group_host, group_path,
     s = service(host, app)
 
     try:
-        ips = set()
-        addrinfo = socket.getaddrinfo(group_host, 1025)
-        for res in addrinfo:
-            ips.add(res[4][0])
+        hostname = socket.gethostbyaddr(group_host)[0]
     except Exception:
-        print warn('Failed to resolve hostname {0}'.format(group_host))
+        print warn('Failed to get hostname for {0}'.format(group_host))
         return
 
     group_path = os.path.normpath(group_path) + '/'
 
-    ips_res = []
-    for ip in ips:
-        res = s.enqueue('search_history_by_path', msgpack.packb([
-            {'host': ip,
-             'path': group_path,
-             'last': last}])).get()
+    res = s.enqueue('search_history_by_path', msgpack.packb([
+        {'host': hostname,
+         'path': group_path,
+         'last': last}])).get()
 
-        if isinstance(res, dict):
-            # error
-            print res
-        else:
-            ips_res.extend(res)
+    if isinstance(res, dict):
+        # error
+        print res
+        return 1
 
     if json:
         print dumps(res)
@@ -385,7 +379,7 @@ def group_search_by_path(group_host, group_path,
 
     print color('{0:^25} | {1:^10} | {2:^50} | {3:^15}'.format(
         'Date', 'Group id', 'Nodes', 'Type of record'), GREEN)
-    for r in ips_res:
+    for r in res:
         for nodes in r['set'][:1]:
             print '{0:25} | {1:>10} | {2:50} | {3}'.format(
                 ts_to_dt(r['timestamp']), r['group'], nodes, r['type'])

--- a/src/python-mastermind/src/mastermind/query/history.py
+++ b/src/python-mastermind/src/mastermind/query/history.py
@@ -25,7 +25,7 @@ class CoupleHistoryRecord(object):
 
 class NodeBackendSetHistoryRecord(object):
     def __init__(self, data):
-        self.set = [NodeBackendHistoryRecord(ns) for ns in data['set']]
+        self.set = [NodeBackendHistoryRecord(**ns) for ns in data['set']]
         self.timestamp = data['timestamp']
         self.type = data['type']
 
@@ -38,20 +38,20 @@ class NodeBackendSetHistoryRecord(object):
 
 
 class NodeBackendHistoryRecord(object):
-    def __init__(self, data):
-        self.addr = data[0]
-        self.port = data[1]
-        self.family = data[2]
-        self.backend_id = data[3]
-        self.base_path = data[4]
+    def __init__(self, hostname, port, family, backend_id, path):
+        self.hostname = hostname
+        self.port = port
+        self.family = family
+        self.backend_id = backend_id
+        self.path = path
 
     def __str__(self):
-        return '{host}:{port}:{family}/{backend_id} {path}'.format(
-            host=self.addr,
+        return '{hostname}:{port}:{family}/{backend_id} {path}'.format(
+            hostname=self.hostname,
             port=self.port,
             family=self.family,
             backend_id=self.backend_id,
-            path=self.base_path)
+            path=self.path)
 
     def __repr__(self):
         return '<{}: {}>'.format(type(self).__name__, str(self))


### PR DESCRIPTION
Previously group history workflow was implemented as follows:
- all group history records were stored in metaelliptics;
- all records were fetched asynchronously and periodically
  and saved in an internal state map.

This solution was accompanied by the following drawbacks:
- desicions could be made based on outdated history records;
- elliptics inconsistencies could result in fetching outdated
  records from meta db;
- increased bandwidth usage (fetching all records every time);

Now when we moved group history records to mongo db, we change our workflow as follows:
- group history records are fetched directly from mongo db
  when required;
- group history state record will try to be updated only on certain
  trigger events that can actually cause history record to change.

How this solves former workflow problems:
- no outdated history records, history records are taken 
  straight from mongo when required;
- no inconsistencies since we use primary-preffered read preference,
  so we can always get most recent history record
  as soon as update query is completed; 
- less network traffic: we only need to check history records
  of all groups on worker startup. After that only groups
  that triggered certain events will try to be updated;

As a bonus:
- only manual- and job-related history state changes are fetched
  periodically to sync state between workers. This is much more
  effective approach.

This pull request contains:
- group history ORM implementation;
- changed workflow implementation described above;
- new cache object for storing hostname-to-IP-addresses mappings;
- ~~group history migration script.~~
