### PR TITLE
Fix settings comparison with basic python types

### DIFF
--- a/src/python-mastermind/src/mastermind/query/namespaces.py
+++ b/src/python-mastermind/src/mastermind/query/namespaces.py
@@ -205,6 +205,14 @@ class NamespaceDataObject(LazyDataObject):
         def __len__(self):
             return len(self._settings)
 
+        def __eq__(self, other):
+            if isinstance(other, NamespaceDataObject.Settings):
+                return self._settings == other._settings
+            return self._settings == other
+
+        def __ne__(self, other):
+            return not self == other
+
         def keys(self):
             return self._settings.keys()
 


### PR DESCRIPTION
Namespace settings dictionary is being wrapped in a special wrapper object
for the user to be able to update any subkey separately. This wrapper object
was not able to be compared to basic python types in an obvious way.
This fix adds intuitive equality checking behaviour for settings objects.
