### PR TITLE
Backend status checks

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -139,6 +139,22 @@ void Backend::update_status()
         m_calculated.status = OK;
 }
 
+bool Backend::group_changed() const
+{
+    if (m_group == nullptr)
+        return false;
+
+    return (m_group->get_id() != int(m_stat.group));
+}
+
+int Backend::get_old_group_id() const
+{
+    if (m_group == nullptr)
+        return -1;
+
+    return m_group->get_id();
+}
+
 void Backend::set_group(Group & group)
 {
     m_group = &group;

--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -221,6 +221,59 @@ void Backend::push_items(std::vector<std::reference_wrapper<FS>> & filesystems) 
 void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
         bool show_internals) const
 {
+    // JSON looks like this:
+    // {
+    //     "addr": "::1:1025:10/10",
+    //     "all_stat_commit_errors": 0,
+    //     "backend_id": 10,
+    //     "base_size": 2333049958,
+    //     "blob_size": 53687091200,
+    //     "blob_size_limit": 5368709120,
+    //     "defrag_state": 0,
+    //     "effective_free_space": 2728233006,
+    //     "effective_space": 5061282964,
+    //     "error": 0,
+    //     "fragmentation": 0.08474519068511643,
+    //     "free_space": 3035659162,
+    //     "fsid": 8323278684798404738,
+    //     "group": 83,
+    //     "last_start": {
+    //         "ts_sec": 1444498430,
+    //         "ts_usec": 864588
+    //     },
+    //     "max_blob_base_size": 2333049958,
+    //     "max_read_rps": 100,
+    //     "max_write_rps": 100,
+    //     "node": "::1:1025:10",
+    //     "read_ios": 89340,
+    //     "read_only": false,
+    //     "read_rps": 21,
+    //     "records": 27119,
+    //     "records_removed": 2511,
+    //     "records_removed_size": 258561169,
+    //     "records_total": 29630,
+    //     "stalled": 0,
+    //     "stat_commit_rofs_errors_diff": 0,
+    //     "state": 1,
+    //     "status": "OK",
+    //     "timestamp": {
+    //         "tv_sec": 1445866995,
+    //         "tv_usec": 468262,
+    //         "user_friendly": "2015-10-26 16:43:15.468262"
+    //     },
+    //     "total_space": 5368709120,
+    //     "used_space": 2333049958,
+    //     "vfs_bavail": 477906313,
+    //     "vfs_blocks": 480682466,
+    //     "vfs_bsize": 4096,
+    //     "vfs_free_space": 1957504258048,
+    //     "vfs_total_space": 1968875380736,
+    //     "vfs_used_space": 11371122688,
+    //     "want_defrag": 0,
+    //     "write_ios": 1632389,
+    //     "write_rps": 12
+    // }
+
     writer.StartObject();
 
     writer.Key("timestamp");

--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -322,8 +322,6 @@ const char *Backend::status_str(Status status)
         return "OK";
     case RO:
         return "RO";
-    case BAD:
-        return "BAD";
     case STALLED:
         return "STALLED";
     case BROKEN:

--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -70,7 +70,10 @@ void Backend::update(const BackendStat & stat)
     double ts2 = double(stat.get_timestamp()) / 1000000.0;
     double d_ts = ts2 - ts1;
 
-    if (d_ts > 1.0) {
+    // Calculating only when d_ts is long enough to make result more smooth.
+    // With forced update we can get two updates within short interval.
+    // In reality, this situation is very rare.
+    if (d_ts > 1.0 && !stat.error) {
         m_calculated.read_rps = int(double(stat.read_ios - m_stat.read_ios) / d_ts);
         m_calculated.write_rps = int(double(stat.write_ios - m_stat.write_ios) / d_ts);
 
@@ -127,9 +130,23 @@ void Backend::recalculate(uint64_t reserved_space)
         std::max(m_calculated.free_space - (m_calculated.total_space - m_calculated.effective_space), 0L);
 }
 
+void Backend::check_stalled(uint64_t stall_timeout_sec)
+{
+    uint64_t ts_now = 0;
+    clock_get(ts_now);
+    ts_now /= 1000000000ULL;
+
+    if (ts_now <= m_stat.ts_sec) {
+        m_calculated.stalled = false;
+        return;
+    }
+
+    m_calculated.stalled = ((ts_now - m_stat.ts_sec) > stall_timeout_sec);
+}
+
 void Backend::update_status()
 {
-    if (m_stat.error || m_stat.state != DNET_BACKEND_ENABLED || m_fs == nullptr)
+    if (m_calculated.stalled || m_stat.state != DNET_BACKEND_ENABLED || m_fs == nullptr)
         m_calculated.status = STALLED;
     else if (m_fs->get_status() == FS::BROKEN)
         m_calculated.status = BROKEN;
@@ -308,6 +325,8 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     if (show_internals) {
         writer.Key("stat_commit_rofs_errors");
         writer.Uint64(m_stat.stat_commit_rofs_errors);
+        writer.Key("stalled");
+        writer.Uint64(m_calculated.stalled);
     }
 
     writer.EndObject();

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -80,7 +80,6 @@ public:
         INIT = 0,
         OK,
         RO,
-        BAD,
         STALLED,
         BROKEN
     };

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -137,6 +137,13 @@ public:
     void set_fs(FS & fs);
     void recalculate(uint64_t reserved_space);
     void update_status();
+
+    // Returns true if bound Group object differs from one in a new stat.
+    // If group is unchanged or not bound, returns false.
+    bool group_changed() const;
+    // Id of currently bound Group.
+    int get_old_group_id() const;
+    // Bind current Group object
     void set_group(Group & group);
 
     void merge(const Backend & other, bool & have_newer);

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -77,11 +77,11 @@ class Backend
 public:
     enum Status
     {
-        INIT = 0,
-        OK,
-        RO,
-        STALLED,
-        BROKEN
+        INIT = 0, // No updates yet
+        OK,       // Enabled, no errors
+        RO,       // Read-Only
+        STALLED,  // Disabled or information is outdated
+        BROKEN    // Misconfig
     };
 
     static const char *status_str(Status status);

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -64,6 +64,12 @@ struct BackendStat
     uint64_t max_blob_base_size;
     uint64_t blob_size;
     uint64_t group;
+
+    uint64_t read_only;
+    uint64_t last_start_ts_sec;
+    uint64_t last_start_ts_usec;
+
+    uint64_t stat_commit_rofs_errors;
 };
 
 class Backend
@@ -181,10 +187,11 @@ private:
         int max_read_rps;
         int max_write_rps;
 
+        // Number of ROFS errors occurred since previous statistics update.
+        uint64_t stat_commit_rofs_errors_diff;
+
         Status status;
     } m_calculated;
-
-    bool m_read_only;
 };
 
 #endif

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -135,6 +135,8 @@ public:
     void update(const BackendStat & stat);
     void set_fs(FS & fs);
     void recalculate(uint64_t reserved_space);
+
+    void check_stalled(uint64_t stall_timeout_sec);
     void update_status();
 
     // Returns true if bound Group object differs from one in a new stat.
@@ -195,6 +197,8 @@ private:
 
         // Number of ROFS errors occurred since previous statistics update.
         uint64_t stat_commit_rofs_errors_diff;
+
+        bool stalled;
 
         Status status;
     } m_calculated;

--- a/src/collector/Config.h
+++ b/src/collector/Config.h
@@ -40,6 +40,7 @@ struct Config
         forbidden_dht_groups(0),
         forbidden_unmatched_group_total_space(0),
         reserved_space(112742891519),
+        node_backend_stat_stale_timeout(120),
         dnet_log_mask(3),
         net_thread_num(3),
         io_thread_num(3),
@@ -53,6 +54,7 @@ struct Config
     uint64_t forbidden_dht_groups;
     uint64_t forbidden_unmatched_group_total_space;
     uint64_t reserved_space;
+    uint64_t node_backend_stat_stale_timeout;
     uint64_t dnet_log_mask;
     uint64_t net_thread_num;
     uint64_t io_thread_num;
@@ -82,6 +84,7 @@ inline std::ostream & operator << (std::ostream & ostr, const Config & config)
         "forbidden_dht_groups: "                  << config.forbidden_dht_groups << "\n"
         "forbidden_unmatched_group_total_space: " << config.forbidden_unmatched_group_total_space << "\n"
         "reserved_space: "                        << config.reserved_space << "\n"
+        "node_backend_stat_stale_timeout: "       << config.node_backend_stat_stale_timeout << "\n"
         "dnet_log_mask: "                         << config.dnet_log_mask << "\n"
         "net_thread_num: "                        << config.net_thread_num << "\n"
         "io_thread_num: "                         << config.io_thread_num << "\n"

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -40,7 +40,8 @@ enum ConfigKey
     Jobs                              = 0x4000,
     Db                                = 0x8000,
     Options                           = 0x10000,
-    ConnectTimeoutMS                  = 0x20000
+    ConnectTimeoutMS                  = 0x20000,
+    NodeBackendStatStaleTimeout       = 0x100000
 };
 
 std::vector<Parser::FolderVector> config_folders = {
@@ -49,6 +50,7 @@ std::vector<Parser::FolderVector> config_folders = {
         { "forbidden_dht_groups",                  0, ForbiddenDhtGroups                },
         { "forbidden_unmatched_group_total_space", 0, ForbiddenUnmatchedGroupTotalSpace },
         { "reserved_space",                        0, ReservedSpace                     },
+        { "node_backend_stat_stale_timeout",       0, NodeBackendStatStaleTimeout       },
         { "dnet_log_mask",                         0, DnetLogMask                       },
         { "net_thread_num",                        0, NetThreadNum                      },
         { "io_thread_num",                         0, IoThreadNum                       },
@@ -75,6 +77,7 @@ Parser::UIntInfoVector config_uint_info = {
     { ForbiddenDhtGroups,                SET, offsetof(Config, forbidden_dht_groups)                  },
     { ForbiddenUnmatchedGroupTotalSpace, SET, offsetof(Config, forbidden_unmatched_group_total_space) },
     { ReservedSpace,                     SET, offsetof(Config, reserved_space)                        },
+    { NodeBackendStatStaleTimeout,       SET, offsetof(Config, node_backend_stat_stale_timeout)       },
     { DnetLogMask,                       SET, offsetof(Config, dnet_log_mask)                         },
     { NetThreadNum,                      SET, offsetof(Config, net_thread_num)                        },
     { IoThreadNum,                       SET, offsetof(Config, io_thread_num)                         },

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -106,6 +106,11 @@ void Group::add_backend(Backend & backend)
     m_backends.insert(backend);
 }
 
+void Group::remove_backend(Backend & backend)
+{
+    m_backends.erase(backend);
+}
+
 void Group::handle_metadata_download_failed(const std::string & why)
 {
     if (m_internal_status == INIT_Init) {

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -327,7 +327,6 @@ void Group::update_status(bool forbidden_dht)
                 m_update_time = backend_ts;
         }
     } else {
-        bool have_bad = false;
         bool have_ro = false;
         bool have_other = false;
         uint64_t backend_ts = 0;
@@ -339,26 +338,14 @@ void Group::update_status(bool forbidden_dht)
             if (backend_ts < cur_ts)
                 backend_ts = cur_ts;
 
-            if (b_status == Backend::BAD) {
-                have_bad = true;
-                break;
-            } else if (b_status == Backend::RO) {
+            if (b_status == Backend::RO) {
                 have_ro = true;
             } else if (b_status != Backend::OK) {
                 have_other = true;
             }
         }
 
-        if (have_bad) {
-            if (m_internal_status != BAD_HaveBADBackends) {
-                if (m_update_time < backend_ts)
-                    m_update_time = backend_ts;
-
-                m_internal_status = BAD_HaveBADBackends;
-                m_status = BAD;
-                m_status_text = "Some of backends are in state BAD";
-            }
-        } else if (have_ro) {
+        if (have_ro) {
             if (m_metadata.service.migrating) {
                 if (m_active_job != nullptr && m_active_job->get_id() == m_metadata.service.job_id) {
                     m_internal_status = MIGRATING_ServiceMigrating;
@@ -411,7 +398,6 @@ void Group::update_status(bool forbidden_dht)
 void Group::set_coupled_status(bool ok, uint64_t timestamp)
 {
     if (m_internal_status == BROKEN_DHTForbidden ||
-            m_internal_status == BAD_HaveBADBackends ||
             m_internal_status == BAD_HaveOther ||
             m_internal_status == BAD_ParseFailed ||
             m_internal_status == BAD_InconsistentCouple ||
@@ -661,8 +647,6 @@ const char *Group::internal_status_str(InternalStatus status)
         return "INIT_Uncoupled";
     case BROKEN_DHTForbidden:
         return "BROKEN_DHTForbidden";
-    case BAD_HaveBADBackends:
-        return "BAD_HaveBADBackends";
     case BAD_HaveOther:
         return "BAD_HaveOther";
     case BAD_ParseFailed:

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -42,7 +42,6 @@ class Group
         INIT_MetadataFailed,
         INIT_Uncoupled,
         BROKEN_DHTForbidden,
-        BAD_HaveBADBackends,
         BAD_HaveOther,
         BAD_ParseFailed,
         BAD_InconsistentCouple,

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -114,6 +114,7 @@ public:
     { return m_metadata.version; }
 
     void add_backend(Backend & backend);
+    void remove_backend(Backend & backend);
 
     void handle_metadata_download_failed(const std::string & why);
     void save_metadata(const char *metadata, size_t size, uint64_t timestamp);

--- a/src/collector/Node.cpp
+++ b/src/collector/Node.cpp
@@ -107,10 +107,16 @@ void Node::parse_stats(void *arg)
     self.update(node_stat);
 
     std::vector<BackendStat> & backend_stats = parser.get_backend_stats();
+    // map backend id -> error count
+    std::map<unsigned int, uint64_t> & rofs_errors = parser.get_rofs_errors();
     for (BackendStat & stat : backend_stats) {
         // Backend objects in JSON document don't have individual timestamps
         stat.ts_sec = node_stat.ts_sec;
         stat.ts_usec = node_stat.ts_usec;
+
+        auto it = rofs_errors.find(stat.backend_id);
+        if (it != rofs_errors.end())
+            stat.stat_commit_rofs_errors = it->second;
 
         self.handle_backend(stat);
     }

--- a/src/collector/Node.cpp
+++ b/src/collector/Node.cpp
@@ -196,7 +196,15 @@ void Node::handle_backend(const BackendStat & new_stat)
 
     backend.recalculate(m_storage.get_app().get_config().reserved_space);
     new_fs.update(backend);
-    backend.update_status();
+}
+
+void Node::update_backend_status(uint64_t stale_timeout_sec)
+{
+    for (auto it = m_backends.begin(); it != m_backends.end(); ++it) {
+        Backend & backend = it->second;
+        backend.check_stalled(stale_timeout_sec);
+        backend.update_status();
+    }
 }
 
 void Node::update_filesystems()

--- a/src/collector/Node.h
+++ b/src/collector/Node.h
@@ -94,6 +94,8 @@ public:
     std::vector<std::reference_wrapper<Backend>> pick_new_backends()
     { return std::move(m_new_backends); }
 
+    void update_backend_status(uint64_t stale_timeout_sec);
+
     void update_filesystems();
 
     void merge(const Node & other, bool & have_newer);

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -449,7 +449,8 @@ CURL *Round::create_easy_handle(Node *node)
 
     std::ostringstream url;
     url << "http://" << node->get_host().get_addr() << ':'
-        << get_app().get_config().monitor_port << "/?categories=80";
+        << get_app().get_config().monitor_port << "/?categories="
+        << uint32_t(DNET_MONITOR_PROCFS | DNET_MONITOR_BACKEND | DNET_MONITOR_STATS);
 
     curl_easy_setopt(easy, CURLOPT_URL, url.str().c_str());
     curl_easy_setopt(easy, CURLOPT_PRIVATE, node);

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -257,7 +257,7 @@ void Round::step3_prepare_metadata_download(void *arg)
 
     clock_stop(self.m_clock.finish_monitor_stats_and_jobs);
 
-    self.m_storage->update_group_structure();
+    self.m_storage->process_node_backends();
     self.m_storage->process_new_jobs();
 
     self.m_nr_groups = (self.m_type != FORCED_PARTIAL

--- a/src/collector/StatsParser.cpp
+++ b/src/collector/StatsParser.cpp
@@ -20,6 +20,8 @@
 
 #include <cstddef>
 
+#include <errno.h>
+
 namespace {
 
 const uint64_t Backends           = 2ULL;
@@ -63,26 +65,51 @@ const uint64_t NetInterfaceName   = 0x4000000000ULL;
 const uint64_t Receive            = 0x8000000000ULL;
 const uint64_t Transmit           = 0x10000000000ULL;
 const uint64_t Bytes              = 0x20000000000ULL;
+const uint64_t Stats              = 0x40000000000ULL;
+const uint64_t StatName           = 0x80000000000ULL;
+const uint64_t Count              = 0x100000000000ULL;
+const uint64_t ReadOnly           = 0x200000000000ULL;
+const uint64_t LastStart          = 0x400000000000ULL;
+const uint64_t LastStartTvSec     = 0x800000000000ULL;
+const uint64_t LastStartTvUsec    = 0x1000000000000ULL;
+//                                = 0x2000000000000ULL;
+//                                = 0x4000000000000ULL;
+//                                = 0x8000000000000ULL;
+//                                = 0x10000000000000ULL;
+//                                = 0x20000000000000ULL;
+//                                = 0x40000000000000ULL;
+//                                = 0x80000000000000ULL;
+//                                = 0x100000000000000ULL;
+//                                = 0x200000000000000ULL;
+//                                = 0x400000000000000ULL;
+//                                = 0x800000000000000ULL;
+//                                = 0x1000000000000000ULL;
+//                                = 0x2000000000000000ULL;
+//                                = 0x4000000000000000ULL;
+// limit                          = 0x8000000000000000ULL;
 
 std::vector<Parser::FolderVector> backend_folders = {
     {
         { "backends",  0, Backends  },
         { "timestamp", 0, Timestamp },
-        { "procfs",    0, Procfs    }
+        { "procfs",    0, Procfs    },
+        { "stats",     0, Stats     }
     },
     {
         { MATCH_ANY, Backends,  BackendFolder },
         { "tv_sec",  Timestamp, TvSec         },
         { "tv_usec", Timestamp, TvUsec        },
         { "vm",      Procfs,    Vm            },
-        { "net",     Procfs,    Net           }
+        { "net",     Procfs,    Net           },
+        { MATCH_ANY, Stats,     StatName      }
     },
     {
         { "backend",        Backends|BackendFolder, Backend       },
         { "backend_id",     Backends|BackendFolder, BackendId     },
         { "status",         Backends|BackendFolder, Status        },
         { "la",             Procfs|Vm,              La            },
-        { "net_interfaces", Procfs|Net,             NetInterfaces }
+        { "net_interfaces", Procfs|Net,             NetInterfaces },
+        { "count",          Stats|StatName,         Count         }
     },
     {
         { "dstat",         Backends|BackendFolder|Backend, Dstat            },
@@ -92,6 +119,8 @@ std::vector<Parser::FolderVector> backend_folders = {
         { "base_stats",    Backends|BackendFolder|Backend, BaseStats        },
         { "defrag_state",  Backends|BackendFolder|Status,  DefragState      },
         { "state",         Backends|BackendFolder|Status,  State            },
+        { "read_only",     Backends|BackendFolder|Status,  ReadOnly         },
+        { "last_start",    Backends|BackendFolder|Status,  LastStart        },
         { NOT_MATCH "lo",  Procfs|Net|NetInterfaces,       NetInterfaceName }
     },
     {
@@ -111,6 +140,8 @@ std::vector<Parser::FolderVector> backend_folders = {
         { "blob_size",            Backends|BackendFolder|Backend|Config,       BlobSize           },
         { "group",                Backends|BackendFolder|Backend|Config,       Group              },
         { MATCH_ANY,              Backends|BackendFolder|Backend|BaseStats,    BlobFilename       },
+        { "tv_sec",               Backends|BackendFolder|Status|LastStart,     LastStartTvSec     },
+        { "tv_usec",              Backends|BackendFolder|Status|LastStart,     LastStartTvUsec    },
         { "receive",              Procfs|Net|NetInterfaces|NetInterfaceName,   Receive            },
         { "transmit",             Procfs|Net|NetInterfaces|NetInterfaceName,   Transmit           }
     },
@@ -123,6 +154,7 @@ std::vector<Parser::FolderVector> backend_folders = {
 
 #define BOFF(field) offsetof(StatsParser::Data, backend.field)
 #define NOFF(field) offsetof(StatsParser::Data, node.field)
+#define SOFF(field) offsetof(StatsParser::Data, stat_commit.field)
 
 Parser::UIntInfoVector backend_uint_info = {
     { Backends|BackendFolder|BackendId,                                   SET, BOFF(backend_id)           },
@@ -144,11 +176,15 @@ Parser::UIntInfoVector backend_uint_info = {
     { Backends|BackendFolder|Backend|BaseStats|BlobFilename|BlobBaseSize, MAX, BOFF(max_blob_base_size)   },
     { Backends|BackendFolder|Status|DefragState,                          SET, BOFF(defrag_state)         },
     { Backends|BackendFolder|Status|State,                                SET, BOFF(state)                },
+    { Backends|BackendFolder|Status|ReadOnly,                             SET, BOFF(read_only)            },
+    { Backends|BackendFolder|Status|LastStart|LastStartTvSec,             SET, BOFF(last_start_ts_sec)    },
+    { Backends|BackendFolder|Status|LastStart|LastStartTvUsec,            SET, BOFF(last_start_ts_usec)   },
     { Timestamp|TvSec,                                                    SET, NOFF(ts_sec)               },
     { Timestamp|TvUsec,                                                   SET, NOFF(ts_usec)              },
     { Procfs|Vm|La,                                                       SET, NOFF(la1)                  },
     { Procfs|Net|NetInterfaces|NetInterfaceName|Receive|Bytes,            SUM, NOFF(rx_bytes)             },
-    { Procfs|Net|NetInterfaces|NetInterfaceName|Transmit|Bytes,           SUM, NOFF(tx_bytes)             }
+    { Procfs|Net|NetInterfaces|NetInterfaceName|Transmit|Bytes,           SUM, NOFF(tx_bytes)             },
+    { Stats|StatName|Count,                                               SET, SOFF(count)                }
 };
 
 Parser::StringInfoVector backend_string_info;
@@ -160,11 +196,32 @@ StatsParser::StatsParser()
     super(backend_folders, backend_uint_info, backend_string_info, (uint8_t *) &m_data)
 {}
 
+bool StatsParser::Key(const char* str, rapidjson::SizeType length, bool copy)
+{
+    if (!super::Key(str, length, copy))
+        return false;
+
+    if (m_keys == (Stats|StatName|1) && m_depth == 2) {
+        unsigned int id = 0;
+        unsigned int err = 0;
+        if (sscanf(str, "eblob.%u.disk.stat_commit.errors.%u", &id, &err) == 2) {
+            m_data.stat_commit.backend = id;
+            m_data.stat_commit.err = err;
+        }
+    }
+
+    return true;
+}
+
 bool StatsParser::EndObject(rapidjson::SizeType nr_members)
 {
     if (m_keys == (Backends|BackendFolder|1) && m_depth == 3) {
         m_backend_stats.push_back(m_data.backend);
         std::memset(&m_data.backend, 0, sizeof(m_data.backend));
+    } else if (m_keys == (Stats|StatName|1) && m_depth == 3) {
+        if (m_data.stat_commit.err == EROFS)
+            m_rofs_errors[m_data.stat_commit.backend] = m_data.stat_commit.count;
+        std::memset(&m_data.stat_commit, 0, sizeof(m_data.stat_commit));
     }
 
     return super::EndObject(nr_members);

--- a/src/collector/StatsParser.h
+++ b/src/collector/StatsParser.h
@@ -23,16 +23,27 @@
 #include "Node.h"
 #include "Parser.h"
 
+#include <map>
+
 class StatsParser : public Parser
 {
     typedef Parser super;
 
 public:
     struct Data {
+        Data()
+            : stat_commit()
+        {}
+
         // backend is a currently processing object.
         // It will be put into m_backend_stats.
         BackendStat backend;
         NodeStat node;
+        struct {
+            unsigned int backend;
+            unsigned int err;
+            uint64_t count;
+        } stat_commit;
     };
 
     StatsParser();
@@ -43,12 +54,21 @@ public:
     NodeStat & get_node_stat()
     { return m_data.node; }
 
+    std::map<unsigned int, uint64_t> & get_rofs_errors()
+    { return m_rofs_errors; }
+
 public:
+    virtual bool Key(const char* str, rapidjson::SizeType length, bool copy);
+
     virtual bool EndObject(rapidjson::SizeType nr_members);
+
+    virtual bool Bool(bool b)
+    { return UInteger(b); }
 
 private:
     Data m_data;
     std::vector<BackendStat> m_backend_stats;
+    std::map<unsigned int, uint64_t> m_rofs_errors;
 };
 
 #endif

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -146,6 +146,23 @@ void Storage::handle_backend(Backend & backend)
         it->second.add_backend(backend);
     }
 
+    if (backend.group_changed()) {
+        int old_id = backend.get_old_group_id();
+        auto it_old = m_groups.find(old_id);
+        if (it_old != m_groups.end()) {
+            BH_LOG(m_app.get_logger(), DNET_LOG_INFO,
+                    "Backend %s has moved from group %d to group %d",
+                    backend.get_key().c_str(), old_id, int(backend.get_stat().group));
+
+            it_old->second.remove_backend(backend);
+        } else {
+            BH_LOG(m_app.get_logger(), DNET_LOG_ERROR,
+                    "Internal inconsistency: Backend %s has moved from group %d to group %d "
+                    "but there is no old group in Storage", backend.get_key().c_str(),
+                    old_id, int(backend.get_stat().group));
+        }
+    }
+
     backend.set_group(it->second);
 }
 

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -184,6 +184,20 @@ void Storage::save_new_jobs(std::vector<Job> new_jobs, uint64_t timestamp)
     m_jobs_timestamp = timestamp;
 }
 
+void Storage::process_node_backends()
+{
+    update_group_structure();
+    for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it)
+        it->second.update_backend_status(m_app.get_config().node_backend_stat_stale_timeout);
+}
+
+void Storage::process_node_backends(std::vector<std::reference_wrapper<Node>> & nodes)
+{
+    update_group_structure();
+    for (Node & node : nodes)
+        node.update_backend_status(m_app.get_config().node_backend_stat_stale_timeout);
+}
+
 void Storage::update_group_structure()
 {
     BH_LOG(m_app.get_logger(), DNET_LOG_INFO, "Updating group structure");

--- a/src/collector/Storage.h
+++ b/src/collector/Storage.h
@@ -84,8 +84,9 @@ public:
     // save jobs received from MongoDB
     void save_new_jobs(std::vector<Job> new_jobs, uint64_t timestamp);
 
-    // process newly received backends, i.e. create Group objects
-    void update_group_structure();
+    // process new backends, check if some backends are stalled, update backend statuses
+    void process_node_backends();
+    void process_node_backends(std::vector<std::reference_wrapper<Node>> & nodes);
 
     // process newly received jobs, bind them to groups, update existing jobs,
     // remove completed/cancelled jobs, unbind them from groups
@@ -103,6 +104,9 @@ public:
     void print_json(Filter & filter, bool show_internals, std::string & str);
 
 private:
+    // process newly received backends, i.e. create Group objects
+    void update_group_structure();
+
     void handle_backend(Backend & backend);
 
     Namespace & get_namespace(const std::string & name);

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -15,6 +15,52 @@ functional unit or feature. The format of list is as follows:
 
 ### TESTS
 
+#### Backend:
+
+* **Stat commit errors**. This test checks if backend's `stat_commit_errors` is
+  taken into account during `Backend` status recalculation (when errors occur,
+  backend must be turned read-only).
+  1. *First error*. This test case checks basic functionality. Backend is first
+  initialized and enabled, then the status is calculated. It must be `OK`.
+  The next `BackendStat` is coming with non-zero `stat_commit_errors`. After the
+  status recalculation it must become `RO`.
+  2. *Subsequent errors*. This case checks if backend remains in state `RO`
+  both when nothing changes and when new errors occur. Send two updates:
+  stat with the same number of commit errors and update with greater number
+  of errors.
+  3. *Restart*. This case checks if `Backend` turns into state `OK` after
+  a clean restart. Read-only backend is updated with a stat with more recent
+  `last_start` timestamp.
+  4. *Reset*. Check if backend becomes `OK` when a new number of commit errors
+  is less than previously accounted.
+  5. *Read-only*. Repeat tests #3 and #4 with `status/read_only` set to 1. Make
+  sure backend remains `RO`.
+* **Read-only flag**. This test checks if value of `status/read_only` is taken
+  into account. Backend must be turned into state `RO` when the flag is set.
+  1. *Flag set*. Check if state transition from `OK` to `RO` works fine. Update
+  a backend with `BackendStat` with `read_only` flag set to 1.
+  2. *Flag unset*. Check if reverse transition works. Update backend with stat
+  with the flag unset.
+  3. *Have ROFS errors*. Repeat previous two tests with non-zero
+  `stat_commit_errors`. Status must not change and remain `RO`.
+* **Group change**. This test verifies that change of a group served by backend
+  is correctly handled.
+  1. *Backend move*. Basic functionality check: update a backend with a stat
+  with `group` changed to another existing. Check if backend and affected
+  groups were updated: the backend and the new group are connected, the backend
+  is unbound from the old group.
+  2. *New group*. Update backend with a stat with group which didn't exist.
+  Make sure the new group was created.
+* **Stalled backends**. This test verifies status change of backends whose
+  description wasn't received for configurable amount of time (default is 120
+  seconds). Tests are conducted with timeout set to 1 second.
+  1. *Stalled*. Basic functionality test. Update a backend, wait for two
+  seconds, recalculate status and make sure it became `STALLED`.
+  2. *Resurrection*. Check if resurrection turns backend into state `OK`.
+  Update backend from previous test case with fresh stat.
+  3. *Disabled backend*. Having backend in state `OK`, change `status/state`
+  to `0` (`DNET_BACKEND_DISABLED`). State must become `STALLED`.
+
 #### Couple:
 
 * **DC sharing check**. This test verifies a stage of couple's status


### PR DESCRIPTION
This pull request contains changes regarding backend functionality.
1) `stat_commit_errors` is accounted for `ROFS` errors. When eblob reports it couldn't commit statistics, backend is turned into state `RO`.
2) Backend handles group change. If update comes with new group id, it becomes unbound from old group and bound to a new one.
3) Backend turns into state `STALLED` when description is not coming from elliptics for configurable amount of time (option `node_backend_stat_stale_timeout`).
4) There is one commit removing backend status `BAD` (it was introduced erronously).
@shaitan, please have a look.
