### PR TITLE
Add handler for fetching couple free effective space monitor samples

### DIFF
--- a/src/cocaine-app/balancer.py
+++ b/src/cocaine-app/balancer.py
@@ -1621,6 +1621,29 @@ class Balancer(object):
                 self.collect_couples_free_eff_space
             )
 
+    @h.concurrent_handler
+    def get_monitor_effective_free_space(self, request):
+        try:
+            namespace = request[0]
+        except IndexError:
+            raise ValueError('Namespace is required')
+
+        try:
+            options = request[1]
+        except IndexError:
+            raise ValueError('Query options are required')
+
+        try:
+            samples_limit = int(options['limit'])
+        except (KeyError, TypeError, ValueError):
+            raise ValueError('Query options should contain "limit" parameter')
+
+        return self.couple_free_eff_space_monitor.get_namespace_samples(
+            namespace=namespace,
+            limit=samples_limit,
+            skip=int(options.get('offset', 0))
+        )
+
 
 def handlers(b):
     handlers = []

--- a/src/cocaine-app/monitor.py
+++ b/src/cocaine-app/monitor.py
@@ -33,8 +33,8 @@ class CoupleFreeEffectiveSpaceMonitor(object):
     CFES_STAT_CFG = STAT_CFG.get('couple_free_effective_space', {})
 
     RECORD_WRITE_ATTEMPTS = STAT_CFG.get('write_attempts', 3)
-    MAX_DATA_POINTS = CFES_STAT_CFG.get('max_data_points', 1000)
-    DATA_COLLECT_PERIOD = CFES_STAT_CFG.get('collect_period', 300)
+    MAX_DATA_POINTS = CFES_STAT_CFG.get('max_data_points', 500)
+    DATA_COLLECT_PERIOD = CFES_STAT_CFG.get('collect_period', 3600)
 
     def __init__(self, db):
         self.collection = Collection(db[config['metadata']['statistics']['db']],


### PR DESCRIPTION
Couples' free effective space monitor samples can be used for visualization of couples' free effective space dynamic distribution.
Also, this pull request includes adjustments of monitor collection settings:
- there seems to be no reason for collecting more than 500 samples at a time because this kind of granularity should be more than enough for a graph. Default value is changed accordingly.
- collecting data once in an hour should also be enough for any reasonably used namespace. Default value is changed accordingly.
