### PR TITLE
Group & couple status

### DIFF
--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -70,6 +70,9 @@ struct BackendStat
     uint64_t last_start_ts_usec;
 
     uint64_t stat_commit_rofs_errors;
+
+    std::string data_path;
+    std::string file_path;
 };
 
 class Backend
@@ -130,6 +133,9 @@ public:
     int get_write_rps() const
     { return m_calculated.write_rps; }
 
+    const std::string & get_base_path() const
+    { return m_calculated.base_path; }
+
     bool full() const;
 
     void update(const BackendStat & stat);
@@ -161,6 +167,9 @@ public:
 
     void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
             bool show_internals) const;
+
+private:
+    void calculate_base_path(const BackendStat & stat);
 
 private:
     Node & m_node;
@@ -201,6 +210,8 @@ private:
         bool stalled;
 
         Status status;
+
+        std::string base_path;
     } m_calculated;
 };
 

--- a/src/collector/Collector.cpp
+++ b/src/collector/Collector.cpp
@@ -246,14 +246,17 @@ void Collector::execute_summary(void *arg)
 
     std::map<Backend::Status, int> backend_status;
     std::map<Group::Status, int> group_status;
+    std::map<Group::Type, int> group_type;
     std::map<Couple::Status, int> couple_status;
     std::map<FS::Status, int> fs_status;
     std::map<Job::Status, int> job_status;
     size_t nr_backends = 0;
     size_t nr_filesystems = 0;
 
-    for (auto it = groups.begin(); it != groups.end(); ++it)
+    for (auto it = groups.begin(); it != groups.end(); ++it) {
         ++group_status[it->second.get_status()];
+        ++group_type[it->second.get_type()];
+    }
 
     for (auto it = couples.begin(); it != couples.end(); ++it)
         ++couple_status[it->second.get_status()];
@@ -291,6 +294,9 @@ void Collector::execute_summary(void *arg)
     ostr << ")\n" << groups.size() << " groups\n  ( ";
     for (auto it = group_status.begin(); it != group_status.end(); ++it)
         ostr << it->second << ' ' << Group::status_str(it->first) << ' ';
+    ostr << ")\n  ( ";
+    for (auto it = group_type.begin(); it != group_type.end(); ++it)
+        ostr << it->second << ' ' << Group::type_str(it->first) << ' ';
 
     ostr << ")\n" << couples.size() << " couples\n  ( ";
     for (auto it = couple_status.begin(); it != couple_status.end(); ++it)

--- a/src/collector/Config.h
+++ b/src/collector/Config.h
@@ -59,6 +59,7 @@ struct Config
     uint64_t net_thread_num;
     uint64_t io_thread_num;
     uint64_t nonblocking_io_thread_num;
+    std::string cache_group_path_prefix;
     std::vector<NodeInfo> nodes;
 
     struct {
@@ -98,6 +99,7 @@ inline std::ostream & operator << (std::ostream & ostr, const Config & config)
         "    db: "                                << config.metadata.jobs.db << "\n"
         "  }\n"
         "}\n"
+        "cache_group_path_prefix: "               << config.cache_group_path_prefix << "\n"
         "nodes:\n";
     for (const Config::NodeInfo & node : config.nodes)
         ostr << "  " << node.host << ':' << node.port << ':' << node.family << '\n';

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -41,7 +41,9 @@ enum ConfigKey
     Db                                = 0x8000,
     Options                           = 0x10000,
     ConnectTimeoutMS                  = 0x20000,
-    NodeBackendStatStaleTimeout       = 0x100000
+    NodeBackendStatStaleTimeout       = 0x40000,
+    Cache                             = 0x80000,
+    GroupPathPrefix                   = 0x100000
 };
 
 std::vector<Parser::FolderVector> config_folders = {
@@ -55,15 +57,17 @@ std::vector<Parser::FolderVector> config_folders = {
         { "net_thread_num",                        0, NetThreadNum                      },
         { "io_thread_num",                         0, IoThreadNum                       },
         { "nonblocking_io_thread_num",             0, NonblockingIoThreadNum            },
-        { "metadata",                              0, Metadata                          }
+        { "metadata",                              0, Metadata                          },
+        { "cache",                                 0, Cache                             }
     },
     {
-        { "nodes",        Elliptics, Nodes       },
-        { "monitor_port", Elliptics, MonitorPort },
-        { "wait_timeout", Elliptics, WaitTimeout },
-        { "url",          Metadata,  Url         },
-        { "jobs",         Metadata,  Jobs        },
-        { "options",      Metadata,  Options     }
+        { "nodes",             Elliptics, Nodes           },
+        { "monitor_port",      Elliptics, MonitorPort     },
+        { "wait_timeout",      Elliptics, WaitTimeout     },
+        { "url",               Metadata,  Url             },
+        { "jobs",              Metadata,  Jobs            },
+        { "options",           Metadata,  Options         },
+        { "group_path_prefix", Cache,     GroupPathPrefix }
     },
     {
         { "db",               Metadata|Jobs,    Db               },
@@ -86,8 +90,9 @@ Parser::UIntInfoVector config_uint_info = {
 };
 
 Parser::StringInfoVector config_string_info = {
-    { Metadata|Url,     offsetof(Config, metadata.url)     },
-    { Metadata|Jobs|Db, offsetof(Config, metadata.jobs.db) }
+    { Metadata|Url,     offsetof(Config, metadata.url)                 },
+    { Metadata|Jobs|Db, offsetof(Config, metadata.jobs.db)             },
+    { Cache|GroupPathPrefix, offsetof(Config, cache_group_path_prefix) }
 };
 
 } // unnamed namespace

--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -336,45 +336,6 @@ void Couple::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer, boo
     writer.EndObject();
 }
 
-const char *Couple::internal_status_str(InternalStatus status)
-{
-    switch (status) {
-    case INIT_Init:
-        return "INIT_Init";
-    case BAD_NoGroups:
-        return "BAD_NoGroups";
-    case BAD_DifferentMetadata:
-        return "BAD_DifferentMetadata";
-    case BAD_GroupUninitialized:
-        return "BAD_GroupUninitialized";
-    case BAD_GroupBAD:
-        return "BAD_GroupBAD";
-    case BAD_ReadOnly:
-        return "BAD_ReadOnly";
-    case BAD_DcResolveFailed:
-        return "BAD_DcResolveFailed";
-    case BAD_Unknown:
-        return "BAD_Unknown";
-    case BROKEN_DcSharing:
-        return "BROKEN_DcSharing";
-    case BROKEN_GroupBROKEN:
-        return "BROKEN_GroupBROKEN";
-    case BROKEN_UnequalTotalSpace:
-        return "BROKEN_UnequalTotalSpace";
-    case FROZEN_Frozen:
-        return "FROZEN_Frozen";
-    case FULL_Full:
-        return "FULL_Full";
-    case SERVICE_ACTIVE_ServiceActive:
-        return "SERVICE_ACTIVE_ServiceActive";
-    case SERVICE_STALLED_ServiceStalled:
-        return "SERVICE_STALLED_ServiceStalled";
-    case OK_OK:
-        return "OK_OK";
-    }
-    return "UNKNOWN";
-}
-
 const char *Couple::status_str(Status status)
 {
     switch (status)

--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -274,10 +274,10 @@ void Couple::push_items(std::vector<std::reference_wrapper<FS>> & filesystems) c
         group.push_items(filesystems);
 }
 
-void Couple::account_job_in_status()
+bool Couple::account_job_in_status()
 {
     if (m_status != BAD)
-        return;
+        return false;
 
     for (Group & group : m_groups) {
         if (group.has_active_job()) {
@@ -286,7 +286,7 @@ void Couple::account_job_in_status()
             Job::Status status = job.get_status();
 
             if (type != Job::MOVE_JOB && type != Job::RESTORE_GROUP_JOB)
-                return;
+                return false;
 
             if (status == Job::NEW || status == Job::EXECUTING) {
                 m_internal_status = SERVICE_ACTIVE_ServiceActive;
@@ -305,9 +305,11 @@ void Couple::account_job_in_status()
             if (m_modified_time < group.get_update_time())
                 m_modified_time = group.get_update_time();
 
-            break;
+            return true;
         }
     }
+
+    return false;
 }
 
 int Couple::check_dc_sharing()

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -105,7 +105,9 @@ public:
     { return m_update_status_duration; }
 
 private:
-    void account_job_in_status();
+    // Returns true if active job affected status.
+    bool account_job_in_status();
+
     int check_dc_sharing();
 
 private:

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -35,27 +35,6 @@ class Storage;
 
 class Couple
 {
-    enum InternalStatus {
-        INIT_Init,
-        BAD_NoGroups,
-        BAD_DifferentMetadata,
-        BAD_GroupUninitialized,
-        BAD_GroupBAD,
-        BAD_ReadOnly,
-        BAD_DcResolveFailed,
-        BAD_Unknown,
-        BROKEN_UnequalTotalSpace,
-        BROKEN_DcSharing,
-        BROKEN_GroupBROKEN,
-        FROZEN_Frozen,
-        FULL_Full,
-        SERVICE_ACTIVE_ServiceActive,
-        SERVICE_STALLED_ServiceStalled,
-        OK_OK
-    };
-
-    static const char *internal_status_str(InternalStatus status);
-
 public:
     enum Status {
         INIT,

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -84,7 +84,13 @@ public:
     Status get_status() const
     { return m_status; }
 
-    void update_status(bool forbidden_dc_sharing, bool forbidden_unmatched_total);
+    void update_status(bool forbidden_dht, bool forbidden_dc_sharing, bool forbidden_unmatched_total);
+
+    bool check_groups(const std::vector<int> & group_ids) const;
+
+    uint64_t get_effective_free_space() const;
+
+    bool full();
 
     void merge(const Couple & other, bool & have_newer);
 
@@ -114,7 +120,6 @@ private:
     std::string m_key;
     std::vector<std::reference_wrapper<Group>> m_groups;
 
-    InternalStatus m_internal_status;
     Status m_status;
     std::string m_status_text;
 

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -66,8 +66,7 @@ Group::Group(int id)
     m_active_job(nullptr),
     m_namespace(nullptr),
     m_type(DATA),
-    m_status(INIT),
-    m_internal_status(INIT_Init)
+    m_status(INIT)
 {
     m_metadata.version = 0;
     m_metadata.frozen = false;
@@ -77,7 +76,7 @@ Group::Group(int id)
 bool Group::full() const
 {
     for (const Backend & backend : m_backends) {
-        if (!backend.full())
+        if (!backend.full(/* TODO: ns reserved space */))
             return false;
     }
     return true;
@@ -114,16 +113,10 @@ void Group::remove_backend(Backend & backend)
 
 void Group::handle_metadata_download_failed(const std::string & why)
 {
-    if (m_internal_status != INIT_MetadataFailed) {
-        m_internal_status = INIT_MetadataFailed;
-
-        std::ostringstream ostr;
-        ostr << "Metadata download failed: " << why;
-        m_status_text = ostr.str();
-
-        m_metadata.version = 0;
-        m_clean = true;
-    }
+    // TODO: uncomment when app::logger() will be available
+    // BH_LOG(app::logger(), DNET_LOG_ERROR,
+    //        "Group %d: Metadata download failed: %s", m_id, why.c_str());
+    clear_metadata();
 }
 
 void Group::save_metadata(const char *metadata, size_t size, uint64_t timestamp)
@@ -167,7 +160,6 @@ int Group::parse_metadata()
 
     if (!ostr.str().empty()) {
         m_status_text = ostr.str();
-        m_internal_status = BAD_ParseFailed;
         m_status = BAD;
         return -1;
     }
@@ -275,9 +267,11 @@ int Group::parse_metadata()
     }
 
     if (!ostr.str().empty()) {
+        clear_metadata();
         m_status_text = ostr.str();
-        m_internal_status = BAD_ParseFailed;
         m_status = BAD;
+        // TODO: uncomment when app::logger() will be available
+        // BH_LOG(app::logger(), DNET_LOG_ERROR, "Metadata parse error: %s", m_status_text.c_str());
         return -1;
     }
 
@@ -338,169 +332,174 @@ void Group::clear_active_job()
     m_active_job = nullptr;
 }
 
+void Group::clear_metadata()
+{
+    m_metadata.version = 0;
+    m_metadata.frozen = false;
+    m_metadata.couple.clear();
+    m_metadata.namespace_name.clear();
+    m_metadata.type.clear();
+    m_metadata.service.migrating = false;
+    m_metadata.service.job_id.clear();
+    m_clean = true;
+}
+
 void Group::update_status(bool forbidden_dht)
 {
+    std::ostringstream ostr;
+
+    // No backends -> state INIT
     if (m_backends.empty()) {
-        if (m_internal_status != INIT_NoBackends) {
-            m_internal_status = INIT_NoBackends;
-            m_status = INIT;
-            m_status_text = "No node backends";
-        }
-    } else if (m_backends.size() > 1 && forbidden_dht) {
-        if (m_internal_status != BROKEN_DHTForbidden) {
-            m_internal_status = BROKEN_DHTForbidden;
-            m_status = BROKEN;
+        m_status = INIT;
+        ostr << "Group " << m_id << " is in state INIT because there are "
+                "no node backends serving this group";
+        m_status_text = ostr.str();
+        return;
+    }
 
-            std::ostringstream ostr;
-            ostr << "DHT groups are forbidden but the group has " << m_backends.size() << " backends";
-            m_status_text = ostr.str();
+    // Report BROKEN if the group has several backends but DHT groups are forbidden.
+    if (forbidden_dht && m_backends.size() > 1) {
+        m_status = BROKEN;
+        ostr << "Group " << m_id << " is in state BROKEN because it has "
+             << m_backends.size() << " backends but an option "
+                "'forbidden_dht_groups' is set";
+        m_status_text = ostr.str();
+        return;
+    }
 
-            uint64_t backend_ts = get_backend_update_time();
-            if (m_update_time < backend_ts)
-                m_update_time = backend_ts;
-        }
-    } else {
-        bool have_ro = false;
-        bool have_other = false;
-        uint64_t backend_ts = 0;
+    // No metadata -> state INIT
+    if (!m_metadata.version) {
+        m_status = INIT;
+        ostr << "Group " << m_id << " is in state INIT because meta key "
+                "was not read from it.";
+        m_status_text = ostr.str();
+    }
 
-        for (Backend & backend : m_backends) {
-            Backend::Status b_status = backend.get_status();
+    auto it = std::find_if(m_backends.begin(), m_backends.end(),
+                [] (const Backend & backend) { return backend.get_status() == Backend::BROKEN; });
 
-            uint64_t cur_ts = backend.get_stat().get_timestamp() * 1000ULL;
-            if (backend_ts < cur_ts)
-                backend_ts = cur_ts;
+    // Have BROKEN backend -> state BROKEN
+    if (it != m_backends.end()) {
+        m_status = BROKEN;
+        ostr << "Group " << m_id << " is in state BROKEN because backend "
+             << it->get().get_key() << " is broken.";
+        m_status_text = ostr.str();
+        return;
+    }
 
-            if (b_status == Backend::RO) {
-                have_ro = true;
-            } else if (b_status != Backend::OK) {
-                have_other = true;
-            }
-        }
+    if (m_type == DATA) {
+        // Metadata & couple checks
+        if (update_storage_group_status())
+            return;
+    }
 
-        if (have_ro) {
+    for (const Backend & backend : m_backends) {
+        if (backend.get_status() == Backend::RO) {
             if (m_metadata.service.migrating) {
                 if (m_active_job != nullptr && m_active_job->get_id() == m_metadata.service.job_id) {
-                    m_internal_status = MIGRATING_ServiceMigrating;
+                    // MIGRATING if job is found
                     m_status = MIGRATING;
-
-                    std::ostringstream ostr;
-                    ostr << "Group is migrating, job id is '" << m_metadata.service.job_id << '\'';
+                    ostr << "Group " << m_id << " is migrating, job id is "
+                         << m_metadata.service.job_id << '.';
                     m_status_text = ostr.str();
                 } else {
-                    m_internal_status = BAD_NoActiveJob;
+                    // Job is not found -> state BAD
                     m_status = BAD;
-
-                    std::ostringstream ostr;
-                    ostr << "Group has no active job, but marked as migrating with job id '"
-                         << m_metadata.service.job_id << '\'';
+                    ostr << "Group " << m_id << " has no active job but marked as migrating "
+                            "by job id " << m_metadata.service.job_id << '.';
                     m_status_text = ostr.str();
                 }
             } else {
-                if (m_internal_status != RO_HaveROBackends) {
-                    if (m_update_time < backend_ts)
-                        m_update_time = backend_ts;
-
-                    m_internal_status = RO_HaveROBackends;
-                    m_status = RO;
-                    m_status_text = "Group is read-only because it has read-only backends";
-                }
+                // Have Read-Only backends -> state RO
+                m_status = RO;
+                ostr << "Group " << m_id << " is Read-Only because backend "
+                     << backend.get_key() << " is Read-Only.";
             }
-        } else if (have_other) {
-            if (m_internal_status != BAD_HaveOther) {
-                if (m_update_time < backend_ts)
-                    m_update_time = backend_ts;
-
-                m_internal_status = BAD_HaveOther;
-                m_status = BAD;
-                m_status_text = "Group is in state BAD because some of backends are not in state OK";
-            }
-        } else if (m_metadata_parsed) {
-            m_status_text = "Group is OK";
-            if (!m_metadata.couple.empty()) {
-                m_internal_status = COUPLED_MetadataOK;
-                m_status = COUPLED;
-            } else {
-                m_internal_status = INIT_Uncoupled;
-                m_status = INIT;
-            }
+            return;
         }
     }
-}
 
-void Group::set_coupled_status(bool ok, uint64_t timestamp)
-{
-    if (m_internal_status == BROKEN_DHTForbidden ||
-            m_internal_status == BAD_HaveOther ||
-            m_internal_status == BAD_ParseFailed ||
-            m_internal_status == BAD_InconsistentCouple ||
-            m_internal_status == BAD_DifferentMetadata ||
-            m_internal_status == MIGRATING_ServiceMigrating ||
-            m_internal_status == RO_HaveROBackends)
+    it = std::find_if(m_backends.begin(), m_backends.end(),
+                [] (const Backend & backend) { return backend.get_status() != Backend::OK; });
+
+    // Have BAD backends -> state BAD
+    if (it != m_backends.end()) {
+        m_status = BAD;
+        ostr << "Group " << m_id << " is in state BAD because backend " << it->get().get_key()
+             << " is in state " << Backend::status_str(it->get().get_status());
+        m_status_text = ostr.str();
         return;
-
-    InternalStatus new_internal_status = ok ? COUPLED_Coupled : BAD_CoupleBAD;
-
-    if (m_internal_status != new_internal_status) {
-        if (m_update_time < timestamp)
-            m_update_time = timestamp;
-        m_internal_status = new_internal_status;
-        m_status = ok ? COUPLED : BAD;
-        m_status_text = (ok ? "Group is OK"
-                            : "Group is in state BAD because couple check fails");
     }
+
+    // Everything is fine.
+    m_status = COUPLED;
+    ostr << "Group " << m_id << " is OK";
+    m_status_text = ostr.str();
 }
 
-int Group::check_couple_equals(const Group & other)
+void Group::update_status_recursive(bool forbidden_dht,
+        bool forbidden_dc_sharing, bool forbidden_unmatched_total)
 {
-    if (m_internal_status == INIT_Init ||
-            other.m_internal_status == INIT_Init ||
-            m_internal_status == INIT_MetadataFailed ||
-            other.m_internal_status == INIT_MetadataFailed)
-        return 0;
-
-    if (m_metadata.couple != other.m_metadata.couple) {
-        if (m_internal_status != BAD_InconsistentCouple) {
-            if (m_update_time < other.m_update_time)
-                m_update_time = other.m_update_time;
-
-            std::ostringstream ostr;
-            ostr << "Groups " << m_id << " and " << other.m_id << " have inconsistent couple info";
-            m_status_text = ostr.str();
-            m_internal_status = BAD_InconsistentCouple;
-            m_status = BAD;
-        }
-        return -1;
-    }
-
-    return 0;
+    if (m_couple != nullptr)
+        m_couple->update_status(forbidden_dht, forbidden_dc_sharing, forbidden_unmatched_total);
+    else
+        this->update_status(forbidden_dht);
 }
 
-int Group::check_metadata_equals(const Group & other)
+bool Group::have_metadata_conflict(const Group & other)
 {
-    if (m_internal_status == INIT_Init ||
-            other.m_internal_status == INIT_Init ||
-            m_internal_status == INIT_MetadataFailed ||
-            other.m_internal_status == INIT_MetadataFailed)
-        return 0;
+    if (!m_metadata.version)
+        return false;
 
-    if (m_metadata.frozen != other.m_metadata.frozen ||
-            m_metadata.couple != other.m_metadata.couple ||
-            m_metadata.namespace_name != other.m_metadata.namespace_name) {
-        if (m_internal_status != BAD_DifferentMetadata) {
-            if (m_update_time < other.m_update_time)
-                m_update_time = other.m_update_time;
+    auto my = std::tie(m_metadata.frozen, m_metadata.couple,
+            m_metadata.namespace_name, m_metadata.type);
 
-            std::ostringstream ostr;
-            ostr << "Groups " << m_id << " and " << other.m_id << " have different metadata";
-            m_status_text = ostr.str();
-            m_internal_status = BAD_DifferentMetadata;
-            m_status = BAD;
-        }
-        return -1;
+    auto oth = std::tie(other.m_metadata.frozen, other.m_metadata.couple,
+            other.m_metadata.namespace_name, other.m_metadata.type);
+
+    return (my != oth);
+}
+
+bool Group::update_storage_group_status()
+{
+    std::ostringstream ostr;
+
+    if (m_metadata.couple.empty()) {
+        m_status = INIT;
+        ostr << "Group " << m_id << " is in state INIT because there is no coupling info.";
+        m_status_text = ostr.str();
+        return true;
     }
 
-    return 0;
+    if (m_couple == nullptr) {
+        m_status = BAD;
+        ostr << "Group " << m_id << " is in state BAD because couple was not created.";
+        m_status_text = ostr.str();
+        return true;
+    }
+
+    if (!m_couple->check_groups(m_metadata.couple)) {
+        m_status = BAD;
+        ostr << "Group " << m_id << " is in state BAD because couple check fails.";
+        m_status_text = ostr.str();
+        return true;
+    }
+
+    if (m_metadata.namespace_name.empty()) {
+        m_status = BAD;
+        ostr << "Group " << m_id << " is in state BAD because there is no namespace assigned to it.";
+        m_status_text = ostr.str();
+        return true;
+    }
+
+    if (std::find(m_metadata.couple.begin(), m_metadata.couple.end(), m_id) == m_metadata.couple.end()) {
+        m_status = BROKEN;
+        ostr << "Group " << m_id << " is in state BROKEN because its id is missing in coupling info.";
+        m_status_text = ostr.str();
+        return true;
+    }
+
+    return false;
 }
 
 void Group::set_couple(Couple & couple)
@@ -537,7 +536,6 @@ void Group::merge(const Group & other, bool & have_newer)
     m_type = other.m_type;
     m_status_text = other.m_status_text;
     m_status = other.m_status;
-    m_internal_status = other.m_internal_status;
 }
 
 void Group::push_items(std::vector<std::reference_wrapper<Couple>> & couples) const
@@ -632,8 +630,6 @@ void Group::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
         writer.Bool(m_metadata_parsed);
         writer.Key("metadata_parse_duration");
         writer.Uint64(m_metadata_parse_duration);
-        writer.Key("internal_status");
-        writer.String(internal_status_str(m_internal_status));
 
         writer.Key("metadata_internal");
         writer.StartObject();

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -661,47 +661,6 @@ void Group::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     writer.EndObject();
 }
 
-    enum InternalStatus {
-    };
-
-const char *Group::internal_status_str(InternalStatus status)
-{
-    switch (status)
-    {
-    case INIT_Init:
-        return "INIT_Init";
-    case INIT_NoBackends:
-        return "INIT_NoBackends";
-    case INIT_MetadataFailed:
-        return "INIT_MetadataFailed";
-    case INIT_Uncoupled:
-        return "INIT_Uncoupled";
-    case BROKEN_DHTForbidden:
-        return "BROKEN_DHTForbidden";
-    case BAD_HaveOther:
-        return "BAD_HaveOther";
-    case BAD_ParseFailed:
-        return "BAD_ParseFailed";
-    case BAD_InconsistentCouple:
-        return "BAD_InconsistentCouple";
-    case BAD_DifferentMetadata:
-        return "BAD_DifferentMetadata";
-    case BAD_CoupleBAD:
-        return "BAD_CoupleBAD";
-    case BAD_NoActiveJob:
-        return "BAD_NoActiveJob";
-    case MIGRATING_ServiceMigrating:
-        return "MIGRATING_ServiceMigrating";
-    case RO_HaveROBackends:
-        return "RO_HaveROBackends";
-    case COUPLED_MetadataOK:
-        return "COUPLED_MetadataOK";
-    case COUPLED_Coupled:
-        return "COUPLED_Coupled";
-    }
-    return "UNKNOWN";
-}
-
 const char *Group::status_str(Status status)
 {
     switch (status)

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -66,7 +66,15 @@ public:
         MIGRATING
     };
 
+    enum Type {
+        DATA,
+        CACHE,
+        UNMARKED
+    };
+
     static const char *status_str(Status status);
+
+    static const char *type_str(Type type);
 
     struct BackendLess
     {
@@ -84,6 +92,9 @@ public:
 
     int get_key() const
     { return m_id; }
+
+    Type get_type() const
+    { return m_type; }
 
     Status get_status() const
     { return m_status; }
@@ -118,6 +129,7 @@ public:
     void handle_metadata_download_failed(const std::string & why);
     void save_metadata(const char *metadata, size_t size, uint64_t timestamp);
     int parse_metadata();
+    void calculate_type(const std::string & cache_group_path_prefix);
 
     bool metadata_parsed() const
     { return m_metadata_parsed; }
@@ -181,6 +193,7 @@ private:
         bool frozen;
         std::vector<int> couple;
         std::string namespace_name;
+        std::string type;
         struct {
             bool migrating;
             std::string job_id;
@@ -197,6 +210,8 @@ private:
     Couple *m_couple;
     const Job *m_active_job;
     Namespace *m_namespace;
+
+    Type m_type;
 
     std::string m_status_text;
     Status m_status;

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -146,10 +146,10 @@ public:
     void clear_active_job();
 
     void update_status(bool forbidden_dht);
-    void set_coupled_status(bool ok, uint64_t timestamp);
+    void update_status_recursive(bool forbidden_dht,
+            bool forbidden_dc_sharing, bool forbidden_unmatched_total);
 
-    int check_couple_equals(const Group & other);
-    int check_metadata_equals(const Group & other);
+    bool have_metadata_conflict(const Group & other);
 
     void set_couple(Couple & couple);
 
@@ -172,6 +172,11 @@ public:
 
     uint64_t get_metadata_parse_duration() const
     { return m_metadata_parse_duration; }
+
+private:
+    void clear_metadata();
+
+    bool update_storage_group_status();
 
 private:
     int m_id;
@@ -206,7 +211,8 @@ private:
     // Pointers to a couple, active job, and a namespace of this group.
     // If the information is unknown, e.g. metadata was not loaded,
     // the values are set to nullptr. These objects shouldn't be modified
-    // directly but only used for status checks and by push_items().
+    // directly except that Couple::update_status() is invoked from
+    // update_status_recursive(); also items can be collected by push_items().
     Couple *m_couple;
     const Job *m_active_job;
     Namespace *m_namespace;
@@ -215,7 +221,6 @@ private:
 
     std::string m_status_text;
     Status m_status;
-    InternalStatus m_internal_status;
 };
 
 #endif

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -36,26 +36,6 @@ class Storage;
 
 class Group
 {
-    enum InternalStatus {
-        INIT_Init,
-        INIT_NoBackends,
-        INIT_MetadataFailed,
-        INIT_Uncoupled,
-        BROKEN_DHTForbidden,
-        BAD_HaveOther,
-        BAD_ParseFailed,
-        BAD_InconsistentCouple,
-        BAD_DifferentMetadata,
-        BAD_CoupleBAD,
-        BAD_NoActiveJob,
-        MIGRATING_ServiceMigrating,
-        RO_HaveROBackends,
-        COUPLED_MetadataOK,
-        COUPLED_Coupled
-    };
-
-    static const char *internal_status_str(InternalStatus status);
-
 public:
     enum Status {
         INIT,

--- a/src/collector/Node.cpp
+++ b/src/collector/Node.cpp
@@ -43,10 +43,7 @@ Node::Node(Storage & storage, const Host & host, int port, int family)
     m_family(family)
 {
     m_key = key(host.get_addr().c_str(), port, family);
-
-    std::memset(&m_stat, 0, sizeof(m_stat));
     std::memset(&m_clock, 0, sizeof(m_clock));
-
     m_download_data.reserve(4096);
 }
 
@@ -57,9 +54,7 @@ Node::Node(Storage & storage, const Host & host)
     m_port(0),
     m_family(0)
 {
-    std::memset(&m_stat, 0, sizeof(m_stat));
     std::memset(&m_clock, 0, sizeof(m_clock));
-
     m_download_data.reserve(4096);
 }
 

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -247,6 +247,8 @@ void Storage::update()
         if (group.parse_metadata() != 0)
             continue;
 
+        group.calculate_type(m_app.get_config().cache_group_path_prefix);
+
         const std::string & new_namespace_name = group.get_namespace_name();
         if (old_namespace_name != new_namespace_name) {
             if (!old_namespace_name.empty())

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -232,6 +232,10 @@ void Storage::update()
     for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it)
         it->second.update_filesystems();
 
+    // Update group status, first pass.
+    for (auto it = m_groups.begin(); it != m_groups.end(); ++it)
+        it->second.update_status(m_app.get_config().forbidden_dht_groups);
+
     // Process group metadata and jobs.
     for (auto it = m_groups.begin(); it != m_groups.end(); ++it) {
         Group & group = it->second;
@@ -258,8 +262,6 @@ void Storage::update()
             new_ns.add_group(group);
             group.set_namespace(new_ns);
         }
-
-        group.update_status(m_app.get_config().forbidden_dht_groups);
     }
 
     // Create/update couples depending on changes in group metadata and structure
@@ -300,16 +302,6 @@ void Storage::update()
         if (have_same_couples)
             continue;
 
-        bool md_ok = true;
-        for (size_t i = 1; i < groups.size(); ++i) {
-            if (groups[0].get().check_couple_equals(groups[i]) != 0) {
-                md_ok = false;
-                break;
-            }
-        }
-        if (!md_ok)
-            continue;
-
         std::string key = CoupleKey(group_ids);
         auto cit = m_couples.lower_bound(key);
         if (cit == m_couples.end() || cit->first != key) {
@@ -319,10 +311,9 @@ void Storage::update()
         }
     }
 
-    // Complete couple and group updates
-    for (auto it = m_couples.begin(); it != m_couples.end(); ++it)
-        it->second.update_status(
-                false, // forbidden_dc_sharing_among_groups
+    for (auto it = m_groups.begin(); it != m_groups.end(); ++it)
+        it->second.update_status_recursive(m_app.get_config().forbidden_dht_groups,
+                false, // forbidden_dc_sharing
                 m_app.get_config().forbidden_unmatched_group_total_space);
 
     BH_LOG(m_app.get_logger(), DNET_LOG_INFO, "Storage update completed");

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -83,3 +83,75 @@ groups.
   5. *DHT groups #3*. This test makes sure that detection of wrong setup still
   works fine for DHT groups. Conflicting backends are checked in all
   combinations of sequence numbers within their groups.
+* **Couple status**. This test verifies status calculation for `Couple` (method
+  `Couple::update_status`). Each test case checks the resulting status under
+  certain conditions. Prerequisite of all cases is that none of previous
+  conditions are satisfied.
+  1. *Metadata conflict*. A pair of groups has different metadata (namespace,
+  type, ...). Result: `BAD`. Check different combinations of conflicting groups.
+  2. *Frozen*. Some groups(s) are `FROZEN`. Result: `FROZEN`.
+  3. *Unmatched total*. All groups are `COUPLED`, total space is unmatched.
+  Result: `BROKEN`.
+  4. *Full*. All groups are `COUPLED`, some group(s) are full. Result: `FULL`.
+  5. *OK*. All groups are `COUPLED`. Result: `OK`.
+  6. *Init #1*. Have group in state `INIT`. Result: `INIT`.
+  7. *Broken group*. Have group in state `BROKEN`. Result: `BROKEN`.
+  8. *Bad group*. Have group in state `BAD`. Result: `BAD`.
+  9. *Read-only group*. Have group in state `RO`, no active job. Result: `BAD`.
+  Repeat test for migrating group.
+  10. TODO: double check and extend this list after
+  https://github.com/yandex/mastermind/issues/31.
+  11. TODO: add separate test for `account_job_in_status()` in the same way as
+  for DC sharing.
+
+#### Group:
+
+* **Group type**. This test verifies if type of a group is determined correctly.
+  It depends on four conditions: metadata was downloaded or not (`md` / `!md`),
+  config option `cache_group_path_prefix` is specified (`conf` / `!conf`), have
+  backend with base path beginning with specified cache group path prefix
+  (`have_backend` / `!have_backend`), group type in metadata is `cache`
+  or other. The result of each test case is calculated type.
+  1. *Data #1*. `!md` && `!conf`. Result: `DATA`.
+  2. *Unmarked*. `!md` && `conf` && `have_backend`. Result: `UNMARKED`. The test
+  is repeated with different number of backends (1 and 3), trying each backend
+  having specified prefix.
+  3. *Data #2*. `!md` && `conf` && `!have_backend`. Result: `DATA`.
+  4. *Cache*. `md` && `type=="cache"`. Result: `CACHE`.
+  5. *Data #3*. `md` && `type==""`. Result: `DATA`.
+* **Group status**. This test verifies status calculation for `Group` (method
+  `Group::update_status`). Each test case checks the resulting status under
+  certain conditions. Prerequisite of all cases is that none of previous
+  conditions are satisfied.
+  1. *No backends*. Group has no backends. Result: `INIT`.
+  2. *Forbidden DHT*. DHT groups are forbidden, group has more than one
+  backends. Result: `BROKEN`.
+  3. *No metadata*. Metadata was not parsed. Result: `INIT`.
+  4. *Broken backend*. One or more backends are in state `BROKEN`. Result:
+  `BROKEN`. Test should be passed for different backend layouts (number of
+  backends, position of broken backend).
+  5. *Empty couple*. Group of type `DATA` has empty couple in metadata. Result:
+  `INIT`.
+  6. *Unbound couple*. Couple is defined, but no `Couple` object was bound to
+  the group (`Group::set_couple`). Result: `BAD`.
+  7. *Inconsistent couple #1*. Couple has different set of groups than group's
+  metadata. Result: `BAD`.
+  8. *Inconsistent couple #2*. Some of couple's groups has different couple
+  in metadata. Result: `BAD`.
+  9. *Empty namespace*. Metadata has empty namespace name. Result: `BAD`.
+  10. *Wrong couple*. Group identifier is not present in couple field of
+  metadata. Result: `BROKEN`.
+  11. *RO backend #1*. Have read-only backend, group is migrating (metadata
+  field), active job is bound and its id matches metadata. Result: `MIGRATING`.
+  12. *RO backend #2*. Have `RO` backend, group is migrating, no active job.
+  Result: `BAD`.
+  13. *RO backend #3*. Have `RO` backend, group is migrating, active job id
+  doesn't match metadata. Result: `BAD`.
+  14. *RO backend #4*. Have `RO` backend, group is not marked as migrating.
+  Result: `RO`.
+  15. *Other backend state*. Group has backend(s) in state `STALLED` or `INIT`.
+  Result: `BAD`.
+  16. *Coupled*. If none of conditions above are met, group must be in state
+  `COUPLED`.
+  17. TODO: double check and extend this list after
+  https://github.com/yandex/mastermind/issues/31.


### PR DESCRIPTION
Purpose of these fixes is to make logic of status calculation be the same as in current Python worker.
`Group::update_status()` and `Couple::update_status()` were completely reworked.
See `tests/TODO.md` for expected behavior.
@iderikon, please have a look.
