### PR TITLE
Support for namespace settings

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -139,9 +139,9 @@ void Backend::clone_from(const Backend & other)
     m_calculated = other.m_calculated;
 }
 
-bool Backend::full() const
+bool Backend::full(double reserved_space) const
 {
-    if (m_calculated.used_space >= m_calculated.effective_space)
+    if (m_calculated.used_space >= int64_t(double(m_calculated.effective_space) * (1.0 - reserved_space)))
         return true;
     if (m_calculated.effective_free_space <= 0)
         return true;

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -175,7 +175,7 @@ public:
     const std::string & get_base_path() const
     { return m_calculated.base_path; }
 
-    bool full() const;
+    bool full(double reserved_space = 0.0) const;
 
     void update(const BackendStat & stat);
     void set_fs(FS & fs);

--- a/src/collector/CMakeLists.txt
+++ b/src/collector/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(mastermind-collector
     Discovery.cpp Node.cpp Parser.cpp Host.cpp
-    StatsParser.cpp Metrics.cpp
+    StatsParser.cpp Metrics.cpp Namespace.cpp
     Storage.cpp Group.cpp Couple.cpp
     ConfigParser.cpp WorkerApplication.cpp CocaineHandlers.cpp
     FS.cpp FilterParser.cpp Backend.cpp

--- a/src/collector/Config.h
+++ b/src/collector/Config.h
@@ -39,6 +39,7 @@ struct Config
         wait_timeout(10),
         forbidden_dht_groups(0),
         forbidden_unmatched_group_total_space(0),
+        forbidden_ns_without_settings(0),
         reserved_space(112742891519),
         node_backend_stat_stale_timeout(120),
         dnet_log_mask(3),
@@ -53,6 +54,7 @@ struct Config
     uint64_t wait_timeout;
     uint64_t forbidden_dht_groups;
     uint64_t forbidden_unmatched_group_total_space;
+    uint64_t forbidden_ns_without_settings;
     uint64_t reserved_space;
     uint64_t node_backend_stat_stale_timeout;
     uint64_t dnet_log_mask;
@@ -84,6 +86,7 @@ inline std::ostream & operator << (std::ostream & ostr, const Config & config)
         "wait_timeout: "                          << config.wait_timeout << "\n"
         "forbidden_dht_groups: "                  << config.forbidden_dht_groups << "\n"
         "forbidden_unmatched_group_total_space: " << config.forbidden_unmatched_group_total_space << "\n"
+        "forbidden_ns_without_settings: "         << config.forbidden_ns_without_settings << "\n"
         "reserved_space: "                        << config.reserved_space << "\n"
         "node_backend_stat_stale_timeout: "       << config.node_backend_stat_stale_timeout << "\n"
         "dnet_log_mask: "                         << config.dnet_log_mask << "\n"

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -43,7 +43,8 @@ enum ConfigKey
     ConnectTimeoutMS                  = 0x20000,
     NodeBackendStatStaleTimeout       = 0x40000,
     Cache                             = 0x80000,
-    GroupPathPrefix                   = 0x100000
+    GroupPathPrefix                   = 0x100000,
+    ForbiddenNsWithoutSettings        = 0x200000
 };
 
 std::vector<Parser::FolderVector> config_folders = {
@@ -51,6 +52,7 @@ std::vector<Parser::FolderVector> config_folders = {
         { "elliptics",                             0, Elliptics                         },
         { "forbidden_dht_groups",                  0, ForbiddenDhtGroups                },
         { "forbidden_unmatched_group_total_space", 0, ForbiddenUnmatchedGroupTotalSpace },
+        { "forbidden_ns_without_settings",         0, ForbiddenNsWithoutSettings        },
         { "reserved_space",                        0, ReservedSpace                     },
         { "node_backend_stat_stale_timeout",       0, NodeBackendStatStaleTimeout       },
         { "dnet_log_mask",                         0, DnetLogMask                       },
@@ -80,6 +82,7 @@ Parser::UIntInfoVector config_uint_info = {
     { Elliptics|WaitTimeout,             SET, offsetof(Config, wait_timeout)                          },
     { ForbiddenDhtGroups,                SET, offsetof(Config, forbidden_dht_groups)                  },
     { ForbiddenUnmatchedGroupTotalSpace, SET, offsetof(Config, forbidden_unmatched_group_total_space) },
+    { ForbiddenNsWithoutSettings,        SET, offsetof(Config, forbidden_ns_without_settings)         },
     { ReservedSpace,                     SET, offsetof(Config, reserved_space)                        },
     { NodeBackendStatStaleTimeout,       SET, offsetof(Config, node_backend_stat_stale_timeout)       },
     { DnetLogMask,                       SET, offsetof(Config, dnet_log_mask)                         },

--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -53,6 +53,22 @@ void Couple::update_status()
 
     std::ostringstream ostr;
 
+    for (const Group & group : m_groups) {
+        if (!group.get_version()) {
+            m_status = BAD;
+            ostr << "Group " << group.get_id() << " has empty metadata.";
+            m_status_text = ostr.str();
+            return;
+        }
+        if (m_namespace.get().get_id() != group.get_namespace_name()) {
+            m_status = BAD;
+            ostr << "Couple's namespace '" << m_namespace.get().get_id() << "' doesn't match group's "
+                    "namespace '" << group.get_namespace_name() << "'.";
+            m_status_text = ostr.str();
+            return;
+        }
+    }
+
     for (size_t i = 1; i < m_groups.size(); ++i) {
         if (m_groups[0].get().have_metadata_conflict(m_groups[i].get())) {
             if (!account_job_in_status()) {

--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -29,9 +29,10 @@
 
 #include <algorithm>
 
-Couple::Couple(const std::vector<std::reference_wrapper<Group>> & groups)
+Couple::Couple(const std::vector<std::reference_wrapper<Group>> & groups, Namespace & ns)
     :
     m_groups(groups),
+    m_namespace(ns),
     m_status(INIT),
     m_modified_time(0),
     m_update_status_duration(0)
@@ -197,8 +198,7 @@ void Couple::push_items(std::vector<std::reference_wrapper<Group>> & groups) con
 
 void Couple::push_items(std::vector<std::reference_wrapper<Namespace>> & namespaces) const
 {
-    if (!m_groups.empty())
-        m_groups.front().get().push_items(namespaces);
+    namespaces.push_back(m_namespace.get());
 }
 
 void Couple::push_items(std::vector<std::reference_wrapper<Node>> & nodes) const

--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -81,10 +81,15 @@ void Couple::update_status()
             return;
     }
 
-    //// TODO: Add check for namespaces without settings.
-    //// It will be available as soon as support for namespace settings in mongo is added.
-    // if (app::config().forbidden_ns_without_settings) {
-    // }
+    if (app::config().forbidden_ns_without_settings) {
+        if (m_namespace.get().default_settings()) {
+            m_status = BROKEN;
+            ostr << "Couple " << m_key << " is assigned to namespace '"
+                 << m_namespace.get().get_id() << "' which is not set up";
+            m_status_text = ostr.str();
+            return;
+        }
+    }
 
     size_t nr_coupled = std::count_if(m_groups.begin(), m_groups.end(),
             [] (const Group & group) { return group.get_status() == Group::COUPLED; });
@@ -299,16 +304,61 @@ int Couple::check_dc_sharing()
     return 0;
 }
 
+uint64_t Couple::get_effective_space() const
+{
+    if (m_groups.empty())
+        return 0;
+
+    uint64_t group_effective_space = m_groups[0].get().get_effective_space();
+    for (size_t i = 1; i < m_groups.size(); ++i) {
+        const Group & group = m_groups[i].get();
+        uint64_t eff = group.get_effective_space();
+        if (eff < group_effective_space)
+            group_effective_space = eff;
+    }
+
+    double ns_reserved = m_namespace.get().get_settings().reserved_space;
+    return uint64_t(std::floor(double(group_effective_space) * (1.0 - ns_reserved)));
+}
+
+uint64_t Couple::get_effective_free_space() const
+{
+    if (m_groups.empty())
+        return 0;
+
+    int64_t group_free_space = m_groups[0].get().get_free_space();
+    int64_t group_total_space = m_groups[0].get().get_total_space();
+
+    for (size_t i = 1; i < m_groups.size(); ++i) {
+        const Group & group = m_groups[i].get();
+        int64_t free = group.get_free_space();
+        int64_t total = group.get_total_space();
+
+        if (free < group_free_space)
+            group_free_space = free;
+        if (total < group_total_space)
+            group_total_space = total;
+    }
+
+    int64_t eff = get_effective_space();
+
+    if (group_free_space > (group_total_space - eff))
+        return group_free_space - (group_total_space - eff);
+
+    return 0;
+}
+
 bool Couple::full()
 {
+    double ns_reserved = m_namespace.get().get_settings().reserved_space;
+
     for (const Group & group : m_groups) {
-        if (group.full())
+        if (group.full(ns_reserved))
             return true;
     }
 
-    // TODO
-    // if (get_effective_free_space() <= 0)
-    //    return true;
+    if (!get_effective_free_space())
+        return true;
 
     return false;
 }
@@ -325,6 +375,11 @@ void Couple::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer, boo
     for (Group & group : m_groups)
         writer.Uint64(group.get_id());
     writer.EndArray();
+
+    writer.Key("effective_space");
+    writer.Uint64(get_effective_space());
+    writer.Key("effective_free_space");
+    writer.Uint64(get_effective_free_space());
 
     writer.Key("status");
     writer.String(status_str(m_status));

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -68,6 +68,8 @@ public:
 
     bool check_groups(const std::vector<int> & group_ids) const;
 
+    uint64_t get_effective_space() const;
+
     uint64_t get_effective_free_space() const;
 
     bool full();

--- a/src/collector/Couple.h
+++ b/src/collector/Couple.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <rapidjson/writer.h>
 #include <vector>
+#include <functional>
 
 class Backend;
 class Filter;
@@ -52,7 +53,7 @@ public:
     static const char *status_str(Status status);
 
 public:
-    Couple(const std::vector<std::reference_wrapper<Group>> & groups);
+    Couple(const std::vector<std::reference_wrapper<Group>> & groups, Namespace & ns);
 
     const std::string & get_key() const
     { return m_key; }
@@ -98,6 +99,8 @@ private:
 private:
     std::string m_key;
     std::vector<std::reference_wrapper<Group>> m_groups;
+
+    std::reference_wrapper<Namespace> m_namespace;
 
     Status m_status;
     std::string m_status_text;

--- a/src/collector/FS.cpp
+++ b/src/collector/FS.cpp
@@ -157,7 +157,7 @@ void FS::update_command_stat()
 {
     m_calculated.command_stat.clear();
     for (Backend & backend : m_backends) {
-        if (backend.get_calculated().status == Backend::OK)
+        if (backend.get_calculated().status != Backend::STALLED)
             m_calculated.command_stat += backend.get_calculated().command_stat;
     }
 }

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -64,7 +64,6 @@ Group::Group(int id)
     m_metadata_parse_duration(0),
     m_couple(nullptr),
     m_active_job(nullptr),
-    m_namespace(nullptr),
     m_type(DATA),
     m_status(INIT)
 {
@@ -317,11 +316,6 @@ uint64_t Group::get_backend_update_time() const
     return res;
 }
 
-void Group::set_namespace(Namespace & ns)
-{
-    m_namespace = &ns;
-}
-
 void Group::set_active_job(const Job & job)
 {
     m_active_job = &job;
@@ -545,8 +539,8 @@ void Group::push_items(std::vector<std::reference_wrapper<Couple>> & couples) co
 
 void Group::push_items(std::vector<std::reference_wrapper<Namespace>> & namespaces) const
 {
-    if (m_namespace != nullptr)
-        namespaces.push_back(*m_namespace);
+    if (m_couple != nullptr)
+        m_couple->push_items(namespaces);
 }
 
 void Group::push_items(std::vector<std::reference_wrapper<Node>> & nodes) const

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -72,13 +72,14 @@ Group::Group(int id)
     m_metadata.service.migrating = false;
 }
 
-bool Group::full() const
+bool Group::full(double reserved_space) const
 {
+    // Group is full if any backend is full.
     for (const Backend & backend : m_backends) {
-        if (!backend.full(/* TODO: ns reserved space */))
-            return false;
+        if (backend.full(reserved_space))
+            return true;
     }
-    return true;
+    return false;
 }
 
 uint64_t Group::get_total_space() const
@@ -87,6 +88,24 @@ uint64_t Group::get_total_space() const
 
     for (const Backend & backend : m_backends)
         res += backend.get_calculated().total_space;
+    return res;
+}
+
+uint64_t Group::get_free_space() const
+{
+    uint64_t res = 0;
+
+    for (const Backend & backend : m_backends)
+        res += backend.get_calculated().free_space;
+    return res;
+}
+
+uint64_t Group::get_effective_space() const
+{
+    uint64_t res = 0;
+
+    for (const Backend & backend : m_backends)
+        res += backend.get_calculated().effective_space;
     return res;
 }
 

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -82,9 +82,13 @@ public:
     const Backends & get_backends() const
     { return m_backends; }
 
-    bool full() const;
+    bool full(double reserved_space = 0.0) const;
 
     uint64_t get_total_space() const;
+
+    uint64_t get_free_space() const;
+
+    uint64_t get_effective_space() const;
 
     bool has_active_job() const;
 

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -120,8 +120,6 @@ public:
     // the most recently updated backend
     uint64_t get_backend_update_time() const;
 
-    void set_namespace(Namespace & ns);
-
     void set_active_job(const Job & job);
     void clear_active_job();
 
@@ -194,7 +192,6 @@ private:
     // update_status_recursive(); also items can be collected by push_items().
     Couple *m_couple;
     const Job *m_active_job;
-    Namespace *m_namespace;
 
     Type m_type;
 

--- a/src/collector/Namespace.cpp
+++ b/src/collector/Namespace.cpp
@@ -23,6 +23,12 @@
 #include "Namespace.h"
 #include "Node.h"
 
+Namespace::Namespace(const std::string & id)
+    :
+    m_id(id),
+    m_default_settings(true)
+{}
+
 void Namespace::add_couple(Couple & couple)
 {
     m_couples.insert(couple);

--- a/src/collector/Namespace.cpp
+++ b/src/collector/Namespace.cpp
@@ -1,0 +1,87 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "Backend.h"
+#include "Couple.h"
+#include "FS.h"
+#include "Group.h"
+#include "Namespace.h"
+#include "Node.h"
+
+void Namespace::add_couple(Couple & couple)
+{
+    m_couples.insert(couple);
+}
+
+void Namespace::remove_couple(Couple & couple)
+{
+    m_couples.erase(couple);
+}
+
+void Namespace::push_items(std::vector<std::reference_wrapper<Group>> & groups) const
+{
+    for (Couple & couple : m_couples)
+        couple.push_items(groups);
+}
+
+void Namespace::push_items(std::vector<std::reference_wrapper<Node>> & nodes) const
+{
+    for (Couple & couple : m_couples)
+        couple.push_items(nodes);
+}
+
+void Namespace::push_items(std::vector<std::reference_wrapper<Backend>> & backends) const
+{
+    for (Couple & couple : m_couples)
+        couple.push_items(backends);
+}
+
+void Namespace::push_items(std::vector<std::reference_wrapper<FS>> & filesystems) const
+{
+    for (Couple & couple : m_couples)
+        couple.push_items(filesystems);
+}
+
+void Namespace::push_items(std::vector<std::reference_wrapper<Couple>> & couples) const
+{
+    couples.insert(couples.end(), m_couples.begin(), m_couples.end());
+}
+
+void Namespace::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    // JSON looks like this:
+    // {
+    //     "id": "default",
+    //     "couples": [
+    //         "1:2:3", "4:5:6", "7:8:9"
+    //     ]
+    // }
+
+    writer.StartObject();
+
+    writer.Key("id");
+    writer.String(m_id.c_str());
+
+    writer.Key("couples");
+    writer.StartArray();
+    for (const Couple & couple : m_couples)
+        writer.String(couple.get_key().c_str());
+    writer.EndArray();
+
+    writer.EndObject();
+}

--- a/src/collector/Namespace.h
+++ b/src/collector/Namespace.h
@@ -41,14 +41,30 @@ public:
     };
     typedef std::set<std::reference_wrapper<Couple>, CoupleLess> Couples;
 
+    struct Settings
+    {
+        Settings()
+            : reserved_space(0.0)
+        {}
+
+        double reserved_space;
+    };
+
 public:
-    Namespace(const std::string & id)
-        : m_id(id)
-    {}
+    Namespace(const std::string & id);
+
+    const std::string & get_id() const
+    { return m_id; }
 
     void add_couple(Couple & couple);
 
     void remove_couple(Couple & couple);
+
+    bool default_settings() const
+    { return m_default_settings; }
+
+    const Settings & get_settings() const
+    { return m_settings; }
 
     // Obtain a list of items of certain types related to this namespace,
     // e.g. couples, their groups. References to objects will be pushed
@@ -68,6 +84,9 @@ private:
     // Set of references to couples in this namespace. The objects shouldn't be
     // modified directly but only used by push_items().
     Couples m_couples;
+
+    bool m_default_settings;
+    Settings m_settings;
 };
 
 #endif

--- a/src/collector/Namespace.h
+++ b/src/collector/Namespace.h
@@ -19,75 +19,55 @@
 #ifndef __3eb3aef5_b268_43d7_b417_44b800716ce3
 #define __3eb3aef5_b268_43d7_b417_44b800716ce3
 
+#include <rapidjson/writer.h>
+
 #include <set>
 #include <string>
 #include <vector>
 
+class Backend;
+class Couple;
+class FS;
 class Group;
+class Node;
 
 class Namespace
 {
 public:
-    struct GroupLess
+    struct CoupleLess
     {
-        bool operator () (const Group & a, const Group & b) const
+        bool operator () (const Couple & a, const Couple & b) const
         { return &a < &b; }
     };
-    typedef std::set<std::reference_wrapper<Group>, GroupLess> Groups;
+    typedef std::set<std::reference_wrapper<Couple>, CoupleLess> Couples;
 
 public:
-    Namespace(const std::string & name)
-        : m_name(name)
+    Namespace(const std::string & id)
+        : m_id(id)
     {}
 
-    const std::string & get_name() const
-    { return m_name; }
+    void add_couple(Couple & couple);
 
-    void add_group(Group & group)
-    { m_groups.insert(group); }
-
-    void remove_group(Group & group)
-    { m_groups.erase(group); }
+    void remove_couple(Couple & couple);
 
     // Obtain a list of items of certain types related to this namespace,
     // e.g. couples, their groups. References to objects will be pushed
     // into specified vector.
     // Note that some items may be duplicated.
-    void push_items(std::vector<std::reference_wrapper<Group>> & groups) const
-    {
-        groups.insert(groups.end(), m_groups.begin(), m_groups.end());
-    }
+    void push_items(std::vector<std::reference_wrapper<Group>> & groups) const;
+    void push_items(std::vector<std::reference_wrapper<Node>> & nodes) const;
+    void push_items(std::vector<std::reference_wrapper<Backend>> & backends) const;
+    void push_items(std::vector<std::reference_wrapper<FS>> & filesystems) const;
+    void push_items(std::vector<std::reference_wrapper<Couple>> & couples) const;
 
-    void push_items(std::vector<std::reference_wrapper<Node>> & nodes) const
-    {
-        for (Group & group : m_groups)
-            group.push_items(nodes);
-    }
-
-    void push_items(std::vector<std::reference_wrapper<Backend>> & backends) const
-    {
-        for (Group & group : m_groups)
-            group.push_items(backends);
-    }
-
-    void push_items(std::vector<std::reference_wrapper<FS>> & filesystems) const
-    {
-        for (Group & group : m_groups)
-            group.push_items(filesystems);
-    }
-
-    void push_items(std::vector<std::reference_wrapper<Couple>> & couples) const
-    {
-        for (Group & group : m_groups)
-            group.push_items(couples);
-    }
+    void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
 
 private:
-    const std::string m_name;
+    const std::string m_id;
 
-    // Set of references to groups in this namespace. The objects shouldn't be
+    // Set of references to couples in this namespace. The objects shouldn't be
     // modified directly but only used by push_items().
-    Groups m_groups;
+    Couples m_couples;
 };
 
 #endif

--- a/src/collector/Storage.h
+++ b/src/collector/Storage.h
@@ -109,6 +109,7 @@ private:
 
     void merge_groups(const Storage & other_storage, bool & have_newer);
     void merge_jobs(const Storage & other_storage, bool & have_newer);
+    void merge_namespaces(const Storage & other_storage, bool & have_newer);
     void merge_couples(const Storage & other_storage, bool & have_newer);
     void merge_nodes(const Storage & other_storage, bool & have_newer);
     void merge_hosts(const Storage & other_storage, bool & have_newer);

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -70,6 +70,10 @@ functional unit or feature. The format of list is as follows:
   (**TODO**: docs).
   3. *Immediate update*. Make sure update coming less than one second after
   previous one doesn't affect values.
+* **Full check**. This test checks `Backend::full()` method. **TODO: docs**.
+  1. *Default settings*. No reserved space. Check result with empty, non-empty,
+  and full backend.
+  2. *Non-zero reserved space*. Repeat calculations with reserved space 0.5.
 
 #### Couple:
 
@@ -113,6 +117,20 @@ groups.
   https://github.com/yandex/mastermind/issues/31.
   11. TODO: add separate test for `account_job_in_status()` in the same way as
   for DC sharing.
+* **Namespace without settings**. This test checks whether Couple is reported
+  `BROKEN` when no namespace settings found.
+  1. *Correct setup*. Having couple in namespace which is set up
+  `update_status` must set state `OK`.
+  2. *Incorrect setup*. Check if couple detects misconfig: having namespace with
+  default settings make sure that state is reported as `BROKEN`.
+* **Effective space calculation**. Verify `Couple::get_effective_space()`.
+  **TODO**: docs.
+  1. *Default settings*. Check returned value with namespace with default
+  settings.
+  2. *Configured namespace*. Repeat check with NS reserved space set to 0.0,
+  and to 0.5.
+* **Full check**. Verify calculation of `Couple::full()`. Test cases as the
+  same as for test **Effective space calculation**.
 
 #### Group:
 
@@ -165,6 +183,9 @@ groups.
   `COUPLED`.
   17. TODO: double check and extend this list after
   https://github.com/yandex/mastermind/issues/31.
+* **Effective space**. Veryfy calculations of `get_free_space()` and
+  `get_effective_space()`. Test cases are the same as for Couple's test
+  **Effective space**. **TODO**: docs.
 
 #### Filesystem:
 
@@ -189,3 +210,10 @@ groups.
 * **CommandStat summation**. This test checks whether aggregate disk and net RW
   rates are correctly calculated for nodes. Test cases are the same as in
   Filesystem's test **CommandStat summation**.
+
+#### Namespace:
+
+* **Inconsistent metadata**. Check whether all namespaces are created if groups
+  in couple have different namespace in metadata.
+* **Storage merge**. Check whether all namespaces are cloned in
+  `Storage::merge()`.


### PR DESCRIPTION
This changeset adds support for namespace settings. The only parameter which is now used by Mastermind is `reserved_space`. It is a fraction of space needed for Elliptics to be able to update keys in groups with no free space for user data.

Commit summary:
- **Bind couples to namespaces**. Before this commit groups were bound to namespaces.
- **Config options for namespace settings**. This commit adds option `forbidden_ns_without_settings` in Config.
- **Add support for namespace settings**. Functional changes related to namespace settings.
- **Update status check**. This commit synchronizes logic with Python worker. See https://github.com/yandex/mastermind/commit/248ca70a0711692c69f605729e5bb561cf598a90
- **Add tests TODO**. TODO for tests. Note that test description adds TODO for documentation (calculations of effective_space, full, etc. must be documented).
