### PR TITLE
Group history

### DIFF
--- a/src/collector/CMakeLists.txt
+++ b/src/collector/CMakeLists.txt
@@ -4,7 +4,9 @@ add_executable(mastermind-collector
     Storage.cpp Group.cpp Couple.cpp
     ConfigParser.cpp WorkerApplication.cpp CocaineHandlers.cpp
     FS.cpp FilterParser.cpp Backend.cpp
-    Filter.cpp Round.cpp Collector.cpp Job.cpp main.cpp)
+    Filter.cpp Round.cpp Collector.cpp Job.cpp main.cpp
+    GroupHistoryEntry.cpp
+    )
 
 target_link_libraries(mastermind-collector
     ${elliptics_cpp_LIBRARY} ${elliptics_client_LIBRARY}

--- a/src/collector/Collector.cpp
+++ b/src/collector/Collector.cpp
@@ -310,7 +310,7 @@ void Collector::execute_summary(void *arg)
 
     ostr << "Round metrics:\n"
             "  Total time: " << MSEC(self.m_round_clock.total) << " ms\n"
-            "  Jobs database: " << MSEC(self.m_round_clock.jobs_database) << " ms\n"
+            "  Jobs & history databases: " << MSEC(self.m_round_clock.mongo) << " ms\n"
             "  HTTP download time: " << MSEC(self.m_round_clock.perform_download) << " ms\n"
             "  Remaining JSON parsing and jobs processing after HTTP download completed: "
                 << MSEC(self.m_round_clock.finish_monitor_stats_and_jobs) << " ms\n"

--- a/src/collector/Config.h
+++ b/src/collector/Config.h
@@ -71,6 +71,9 @@ struct Config
         } options;
         struct {
             std::string db;
+        } history;
+        struct {
+            std::string db;
         } jobs;
     } metadata;
 
@@ -97,6 +100,9 @@ inline std::ostream & operator << (std::ostream & ostr, const Config & config)
         "  url: "                                 << config.metadata.url << "\n"
         "  options: {\n"
         "    metadata_connect_timeout_ms: "       << config.metadata.options.connectTimeoutMS << "\n"
+        "  }\n"
+        "  history: {\n"
+        "    db: "                                << config.metadata.history.db << "\n"
         "  }\n"
         "  jobs: {\n"
         "    db: "                                << config.metadata.jobs.db << "\n"

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -38,13 +38,14 @@ enum ConfigKey
     Metadata                          = 0x1000,
     Url                               = 0x2000,
     Jobs                              = 0x4000,
-    Db                                = 0x8000,
-    Options                           = 0x10000,
-    ConnectTimeoutMS                  = 0x20000,
-    NodeBackendStatStaleTimeout       = 0x40000,
-    Cache                             = 0x80000,
-    GroupPathPrefix                   = 0x100000,
-    ForbiddenNsWithoutSettings        = 0x200000
+    History                           = 0x8000,
+    Db                                = 0x10000,
+    Options                           = 0x20000,
+    ConnectTimeoutMS                  = 0x40000,
+    NodeBackendStatStaleTimeout       = 0x80000,
+    Cache                             = 0x100000,
+    GroupPathPrefix                   = 0x200000,
+    ForbiddenNsWithoutSettings        = 0x400000
 };
 
 std::vector<Parser::FolderVector> config_folders = {
@@ -67,11 +68,13 @@ std::vector<Parser::FolderVector> config_folders = {
         { "monitor_port",      Elliptics, MonitorPort     },
         { "wait_timeout",      Elliptics, WaitTimeout     },
         { "url",               Metadata,  Url             },
+        { "history",           Metadata,  History         },
         { "jobs",              Metadata,  Jobs            },
         { "options",           Metadata,  Options         },
         { "group_path_prefix", Cache,     GroupPathPrefix }
     },
     {
+        { "db",               Metadata|History, Db               },
         { "db",               Metadata|Jobs,    Db               },
         { "connectTimeoutMS", Metadata|Options, ConnectTimeoutMS }
     }
@@ -94,6 +97,7 @@ Parser::UIntInfoVector config_uint_info = {
 
 Parser::StringInfoVector config_string_info = {
     { Metadata|Url,     offsetof(Config, metadata.url)                 },
+    { Metadata|History|Db, offsetof(Config, metadata.history.db)       },
     { Metadata|Jobs|Db, offsetof(Config, metadata.jobs.db)             },
     { Cache|GroupPathPrefix, offsetof(Config, cache_group_path_prefix) }
 };

--- a/src/collector/ConfigParser.cpp
+++ b/src/collector/ConfigParser.cpp
@@ -96,9 +96,9 @@ Parser::UIntInfoVector config_uint_info = {
 };
 
 Parser::StringInfoVector config_string_info = {
-    { Metadata|Url,     offsetof(Config, metadata.url)                 },
-    { Metadata|History|Db, offsetof(Config, metadata.history.db)       },
-    { Metadata|Jobs|Db, offsetof(Config, metadata.jobs.db)             },
+    { Metadata|Url,          offsetof(Config, metadata.url)            },
+    { Metadata|History|Db,   offsetof(Config, metadata.history.db)     },
+    { Metadata|Jobs|Db,      offsetof(Config, metadata.jobs.db)        },
     { Cache|GroupPathPrefix, offsetof(Config, cache_group_path_prefix) }
 };
 

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -154,7 +154,7 @@ void Group::save_metadata(const char *metadata, size_t size, uint64_t timestamp)
             !std::memcmp(&m_metadata_file[0], metadata, size))
         return;
 
-    clock_get(m_update_time);
+    clock_get_real(m_update_time);
     m_metadata_file.assign(metadata, metadata + size);
     m_clean = false;
 }

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -24,6 +24,7 @@
 #include "Filter.h"
 #include "FS.h"
 #include "Group.h"
+#include "GroupHistoryEntry.h"
 #include "Metrics.h"
 #include "Node.h"
 #include "Storage.h"
@@ -135,6 +136,27 @@ void Group::add_backend(Backend & backend)
 void Group::remove_backend(Backend & backend)
 {
     m_backends.erase(backend);
+}
+
+void Group::apply(const GroupHistoryEntry & entry)
+{
+    auto & backends = entry.get_backends();
+    bool changed = false;
+    for (Backends::iterator it = m_backends.begin(); it != m_backends.end();) {
+        const std::string & key = it->get().get_key();
+        if (backends.find(key) == backends.end()) {
+            m_backends.erase(it++);
+            changed = true;
+        } else {
+            ++it;
+        }
+    }
+    if (changed) {
+        if (double(m_update_time) < entry.get_timestamp())
+            m_update_time = entry.get_timestamp();
+        else
+            clock_get_real(m_update_time);
+    }
 }
 
 void Group::handle_metadata_download_failed(const std::string & why)
@@ -526,6 +548,9 @@ bool Group::match_couple(const Group & other) const
 
 void Group::merge(const Group & other, bool & have_newer)
 {
+    /// XXX
+    // Merge logic should be removed in the near future.
+
     if (m_update_time > other.m_update_time) {
         have_newer = true;
         return;
@@ -533,6 +558,16 @@ void Group::merge(const Group & other, bool & have_newer)
 
     if (m_update_time == other.m_update_time)
         return;
+
+    for (Backends::iterator it = m_backends.begin(); it != m_backends.end();) {
+        const std::string & key = it->get().get_key();
+        auto oth_it = std::find_if(other.m_backends.begin(), other.m_backends.end(),
+                [key] (const Backend & backend) { return backend.get_key() == key; });
+        if (oth_it == other.m_backends.end())
+            m_backends.erase(it++);
+        else
+            ++it;
+    }
 
     m_clean = other.m_clean;
     m_metadata_file = other.m_metadata_file;

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -31,6 +31,7 @@
 class Backend;
 class Couple;
 class Filter;
+class GroupHistoryEntry;
 class Namespace;
 class Storage;
 
@@ -115,6 +116,10 @@ public:
 
     void add_backend(Backend & backend);
     void remove_backend(Backend & backend);
+
+    // Apply history entry from history database.
+    // Group backends which are absent in entry will be removed.
+    void apply(const GroupHistoryEntry & entry);
 
     void handle_metadata_download_failed(const std::string & why);
     void save_metadata(const char *metadata, size_t size, uint64_t timestamp);

--- a/src/collector/GroupHistoryEntry.cpp
+++ b/src/collector/GroupHistoryEntry.cpp
@@ -1,0 +1,88 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "WorkerApplication.h"
+
+#include "GroupHistoryEntry.h"
+
+#include <vector>
+
+GroupHistoryEntry::GroupHistoryEntry(mongo::BSONObj & obj)
+    :
+    m_group_id(0),
+    m_timestamp(0.0),
+    m_empty(true)
+{
+    m_group_id = obj["group_id"].Number();
+
+    std::vector<mongo::BSONElement> nodes = obj["nodes"].Array();
+    for (mongo::BSONElement & node : nodes) {
+        mongo::BSONObj node_obj = node.Obj();
+        parse_backend_history_entry(node_obj);
+    }
+}
+
+void GroupHistoryEntry::parse_backend_history_entry(mongo::BSONObj & obj)
+{
+    std::set<std::string> backends;
+    double cur_ts = 0.0;
+
+    // Insert the most recent backend.
+    cur_ts = obj["timestamp"].Number();
+    if (cur_ts < m_timestamp)
+        return;
+
+    // We are not interested in entries of type automatic.
+    std::string type = obj["type"].String();
+    if (type == "automatic")
+        return;
+
+    std::vector<mongo::BSONElement> set = obj["set"].Array();
+    for (mongo::BSONElement & back_elem : set) {
+        // TODO: Check element types in database records created by mastermind
+
+        long backend_id = back_elem["backend_id"].Number();
+        std::string hostname = back_elem["hostname"].String();
+        int port = back_elem["port"].Number();
+        int family = back_elem["family"].Number();
+
+        std::ostringstream ostr;
+        ostr << hostname << ':' << port << ':' << family << '/' << backend_id;
+        backends.insert(ostr.str());
+    }
+
+    m_backends.swap(backends);
+    m_timestamp = cur_ts;
+    m_empty = false;
+}
+
+std::string GroupHistoryEntry::to_string() const
+{
+    std::ostringstream ostr;
+
+    ostr << "{\n"
+            "  timestamp: " << m_timestamp << "\n"
+            "  group_id: " << m_group_id << "\n"
+            "  backends:\n"
+            "  [\n";
+    for (const std::string & backend : m_backends)
+        ostr << "    " << backend << '\n';
+    ostr << "  ]\n}";
+
+    return ostr.str();
+}

--- a/src/collector/GroupHistoryEntry.h
+++ b/src/collector/GroupHistoryEntry.h
@@ -1,0 +1,96 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#ifndef __9aa43a1c_afa6_4bf7_a90c_b16d0ba55bb1
+#define __9aa43a1c_afa6_4bf7_a90c_b16d0ba55bb1
+
+#include <mongo/bson/bson.h>
+
+#include <set>
+#include <string>
+
+// Sample history database entry:
+//
+// {
+//     "_id" : ObjectId("5617ce09e9024701cf86922e"),
+//     "group_id" : 200,
+//     "nodes" : [
+//         {
+//             "timestamp" : 1446731759,
+//             "type" : "automatic",
+//             "set" : [
+//                 {
+//                     "path" : "/path/to/storage/1/2/",
+//                     "backend_id" : 100,
+//                     "hostname" : "node01.example.com",
+//                     "port" : 1025,
+//                     "family" : 10
+//                 }
+//             ]
+//         },
+//         {
+//             "timestamp" : 1446738868,
+//             "type" : "job",
+//             "set" : [ ]
+//         }
+//     ]
+// }
+//
+// Array "nodes" contains audit of set of node backends serving the group. Each
+// entry has fields "timestamp", "type", and "set".
+//
+// "timestamp" is a point when the entry was created (for example, when
+// a job completed).
+// "type" can either be "automatic" (created by mastermind), "manual" (created
+// by user request), "job" (created by job mechanism).
+// "set" is the current full set of node backends.
+
+class GroupHistoryEntry
+{
+public:
+    GroupHistoryEntry(mongo::BSONObj & obj);
+
+    int get_group_id() const
+    { return m_group_id; }
+
+    const std::set<std::string> & get_backends() const
+    { return m_backends; }
+
+    double get_timestamp() const
+    { return m_timestamp; }
+
+    // Empty means that information about this group found in
+    // the database is valid but there were nothing we were
+    // looking for (i.e. no records of type "job" and "manual").
+    bool empty() const
+    { return m_empty; }
+
+    std::string to_string() const;
+
+private:
+    void parse_backend_history_entry(mongo::BSONObj & obj);
+
+private:
+    int m_group_id;
+    std::set<std::string> m_backends;
+    double m_timestamp;
+    bool m_empty;
+};
+
+#endif
+

--- a/src/collector/Metrics.h
+++ b/src/collector/Metrics.h
@@ -66,6 +66,13 @@ inline void clock_get(uint64_t & value)
     value = ts.tv_sec * 1000000000 + ts.tv_nsec;
 }
 
+inline void clock_get_real(uint64_t & value)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    value = ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
 inline void clock_start(uint64_t & value)
 {
     clock_get(value);

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -18,6 +18,7 @@
 
 #include "CocaineHandlers.h"
 #include "FS.h"
+#include "GroupHistoryEntry.h"
 #include "Metrics.h"
 #include "Round.h"
 #include "WorkerApplication.h"
@@ -143,15 +144,15 @@ void Round::start()
             (m_type == REGULAR) ? "regular" : (m_type == FORCED_FULL) ? "forced full" : "forced partial",
             (m_type == FORCED_PARTIAL ? m_entries.nodes.size() : m_storage->get_nodes().size()));
 
-    dispatch_async_f(m_queue, this, &Round::step2_1_jobs);
+    dispatch_async_f(m_queue, this, &Round::step2_1_jobs_and_history);
     dispatch_async_f(m_queue, this, &Round::step2_2_curl_download);
 }
 
-void Round::step2_1_jobs(void *arg)
+void Round::step2_1_jobs_and_history(void *arg)
 {
     Round & self = *static_cast<Round*>(arg);
 
-    Stopwatch watch(self.m_clock.jobs_database);
+    Stopwatch watch(self.m_clock.mongo);
 
     try {
         const Config & config = app::config();
@@ -178,18 +179,20 @@ void Round::step2_1_jobs(void *arg)
             return;
         }
 
+        // Jobs
+
         mongo::BSONObjBuilder builder;
         builder.append("id", 1);
         builder.append("status", 1);
         builder.append("group", 1);
         builder.append("type", 1);
-        mongo::BSONObj fields = builder.obj();
+        mongo::BSONObj jobs_fields = builder.obj();
 
         std::unique_ptr<mongo::DBClientCursor> cursor(conn->query(config.metadata.jobs.db + ".jobs",
                 MONGO_QUERY("status" << mongo::NE << "completed"
                          << "status" << mongo::NE << "cancelled").readPref(
                              mongo::ReadPreference_PrimaryOnly, mongo::BSONArray()),
-                0, 0, &fields).release());
+                0, 0, &jobs_fields).release());
 
         uint64_t ts = 0;
         clock_get_real(ts);
@@ -220,6 +223,48 @@ void Round::step2_1_jobs(void *arg)
                 "Successfully processed %lu of %lu active jobs", jobs.size(), count);
 
         self.m_storage->save_new_jobs(std::move(jobs), ts);
+
+        // History
+
+        // uint64_t group_history_ts = 0;
+        // clock_get_real(group_history_ts);
+        double previous_ts = /* self.m_storage->get_group_history_ts() / 1000000000ULL */ 0.0;
+
+        std::vector<GroupHistoryEntry> group_history;
+
+        // Load all entries newer than previously examined.
+        cursor = conn->query(config.metadata.history.db + ".history",
+                MONGO_QUERY("nodes.timestamp" << mongo::GT << previous_ts).readPref(
+                        mongo::ReadPreference_PrimaryOnly, mongo::BSONArray()));
+
+        while (cursor->more()) {
+            mongo::BSONObj obj = cursor->next();
+
+            try {
+                GroupHistoryEntry entry(obj);
+                if (!entry.empty()) {
+                    BH_LOG(app::logger(), DNET_LOG_INFO,
+                            "Loaded group history entry:\n%s", entry.to_string());
+                    group_history.emplace_back(std::move(entry));
+                }
+            } catch (const mongo::MsgAssertionException & e) {
+                BH_LOG(app::logger(), DNET_LOG_ERROR,
+                        "Failed to parse history database record: %s\nBSON object: %s",
+                        e.what(), obj.jsonString(mongo::Strict, 1));
+            } catch (const std::exception & e) {
+                BH_LOG(app::logger(), DNET_LOG_ERROR,
+                        "Failed to initialize history entry: %s\nBSON object: %s",
+                        e.what(), obj.jsonString(mongo::Strict, 1));
+            } catch (...) {
+                BH_LOG(app::logger(), DNET_LOG_ERROR,
+                        "Initializing history entry: Unknown exception thrown\nBSON object: %s",
+                        obj.jsonString(mongo::Strict, 1));
+            }
+        }
+
+        BH_LOG(app::logger(), DNET_LOG_INFO, "Loaded %lu group history entries", group_history.size());
+
+        // self.m_storage->save_group_history(std::move(group_history), group_history_ts);
 
     } catch (const mongo::DBException & e) {
         BH_LOG(app::logger(), DNET_LOG_ERROR,

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -192,7 +192,7 @@ void Round::step2_1_jobs(void *arg)
                 0, 0, &fields).release());
 
         uint64_t ts = 0;
-        clock_get(ts);
+        clock_get_real(ts);
         std::vector<Job> jobs;
         size_t count = 0;
 

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -226,9 +226,9 @@ void Round::step2_1_jobs_and_history(void *arg)
 
         // History
 
-        // uint64_t group_history_ts = 0;
-        // clock_get_real(group_history_ts);
-        double previous_ts = /* self.m_storage->get_group_history_ts() / 1000000000ULL */ 0.0;
+        uint64_t group_history_ts = 0;
+        clock_get_real(group_history_ts);
+        double previous_ts = self.m_storage->get_group_history_ts() / 1000000000ULL;
 
         std::vector<GroupHistoryEntry> group_history;
 
@@ -264,7 +264,7 @@ void Round::step2_1_jobs_and_history(void *arg)
 
         BH_LOG(app::logger(), DNET_LOG_INFO, "Loaded %lu group history entries", group_history.size());
 
-        // self.m_storage->save_group_history(std::move(group_history), group_history_ts);
+        self.m_storage->save_group_history(std::move(group_history), group_history_ts);
 
     } catch (const mongo::DBException & e) {
         BH_LOG(app::logger(), DNET_LOG_ERROR,

--- a/src/collector/Round.h
+++ b/src/collector/Round.h
@@ -82,7 +82,7 @@ public:
     void start();
 
 private:
-    static void step2_1_jobs(void *arg);
+    static void step2_1_jobs_and_history(void *arg);
     static void step2_2_curl_download(void *arg);
     static void step3_prepare_metadata_download(void *arg);
     static void step4_perform_update(void *arg);
@@ -116,7 +116,7 @@ public:
         ClockStat & operator = (const ClockStat & other);
 
         uint64_t total;
-        uint64_t jobs_database;
+        uint64_t mongo;
         uint64_t perform_download;
         uint64_t finish_monitor_stats_and_jobs;
         uint64_t metadata_download;

--- a/src/collector/Storage.h
+++ b/src/collector/Storage.h
@@ -80,6 +80,13 @@ public:
     // save jobs received from MongoDB
     void save_new_jobs(std::vector<Job> new_jobs, uint64_t timestamp);
 
+    // save group history received from MongoDB
+    void save_group_history(std::vector<GroupHistoryEntry> history, uint64_t timestamp);
+
+    // last group history update
+    uint64_t get_group_history_ts() const
+    { return m_group_history_ts; }
+
     // process new backends, check if some backends are stalled, update backend statuses
     void process_node_backends();
     void process_node_backends(std::vector<std::reference_wrapper<Node>> & nodes);
@@ -174,6 +181,10 @@ private:
     std::map<int, Job> m_new_jobs;
     // time database query was completed
     uint64_t m_jobs_timestamp;
+
+    // group history received from MongoDB
+    std::vector<GroupHistoryEntry> m_group_history;
+    uint64_t m_group_history_ts;
 };
 
 #endif

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -183,9 +183,26 @@ groups.
   `COUPLED`.
   17. TODO: double check and extend this list after
   https://github.com/yandex/mastermind/issues/31.
-* **Effective space**. Veryfy calculations of `get_free_space()` and
+* **Effective space**. Verify calculations of `get_free_space()` and
   `get_effective_space()`. Test cases are the same as for Couple's test
   **Effective space**. **TODO**: docs.
+* **History**. Verify applying of `GroupHistoryEntry` coming from history
+  database. If some of group backends are absent in history entry, they
+  must be removed from Group's set of backends. Actions are performed in
+  `Group::apply(const GroupHistoryEntry &)`. Test cases should be checked
+  for entries of type `manual` and `job`.
+  1. *No changes #1*. Apply entry with the same set of backends. Nothing must
+  change.
+  2. *No changes #2*. Apply entry with the same set of backends plus new
+  backends. Nothing must change.
+  3. *One backend removed*. Apply entry with one backend absent. It must
+  disappear from the list of Group's backends.
+  4. *All backends removed #1*. Apply entry with empty set of backends.
+  List of Group's backends must become empty.
+  5. *All backends removed #2*. Apply entry with totally different set
+  of backends. List of Group's backends must become empty.
+  6. *Automatic history entries*. Make sure entries of type `automatic`
+  are getting skipped.
 
 #### Filesystem:
 
@@ -217,3 +234,18 @@ groups.
   in couple have different namespace in metadata.
 * **Storage merge**. Check whether all namespaces are cloned in
   `Storage::merge()`.
+
+#### GroupHistoryEntry:
+
+* **Initialization from BSONObj**. This test checks `GroupHistoryEntry`
+  construction. See `GroupHistoryEntry.h` for details of BSONObj format.
+  1. *Empty history*. Check object with empty `nodes` and non-zero group id.
+  2. *No group id*. Try to construct object from BSON with no group id.
+  Exception (`std::runtime_error`) must be thrown.
+  3. *One backend*. Try BSON with a single complete backend description.
+  4. *Wrong backend*. Try single backend with number of fields lacking.
+  Repeat test with fields of wrong type.
+  5. *Several backends*. Try BSON with several backends, first all correct,
+  then with one incorrect (lacking fields/wrong field type).
+  6. *Two and three nodes*. Try 2 and 3 audit records and check whether
+  the most recent record is selected.


### PR DESCRIPTION
Group history is a mechanism of indicating that some backends were moved out of a group. Information is stored in MongoDB and contains a list of objects each one corresponding to a group. The object includes audit of the group. Details on record format can be found in header `GroupHistoryEntry.h`.

This changeset introduces implementation of class `GroupHistoryEntry`, download from MongoDB, applying received information to existing groups. It also contains a small fix of modified time calculation for the `Group` (commit 'Use clock_get_real()').

@shaitan, please have a look.
