### PR TITLE
Fix cocaine worker termination

### DIFF
--- a/src/cocaine-app/__init__.py
+++ b/src/cocaine-app/__init__.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 from functools import wraps
 import logging
+import signal
 import sys
 from time import sleep, time
 import traceback
@@ -42,6 +43,15 @@ from manual_locks import manual_locker
 
 i = iter(xrange(100))
 logger.info("trace %d" % (i.next()))
+
+
+def term_handler(signo, frame):
+    # required to guarantee execution of cleanup functions registered
+    # with atexit.register
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, term_handler)
 
 nodes = config.get('elliptics', {}).get('nodes', []) or config["elliptics_nodes"]
 logger.debug("config: %s" % str(nodes))

--- a/src/cocaine-app/cache_worker.py
+++ b/src/cocaine-app/cache_worker.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import logging
+import sys
+import signal
 import time
 
 # NB: pool should be initialized before importing
@@ -164,6 +166,13 @@ def init_job_processor(jf, meta_db, niu):
 
 
 if __name__ == '__main__':
+
+    def term_handler(signo, frame):
+        # required to guarantee execution of cleanup functions registered
+        # with atexit.register
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, term_handler)
 
     n = init_elliptics_node()
 

--- a/src/cocaine-app/inventory_worker.py
+++ b/src/cocaine-app/inventory_worker.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import logging
+import signal
+import sys
 
 from cocaine.asio.exceptions import LocatorResolveError
 from cocaine.worker import Worker
@@ -30,6 +32,13 @@ def init_inventory_worker(worker):
 DEFAULT_DISOWN_TIMEOUT = 2
 
 if __name__ == '__main__':
+
+    def term_handler(signo, frame):
+        # required to guarantee execution of cleanup functions registered
+        # with atexit.register
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, term_handler)
 
     logger.info("before creating inventory worker")
     worker = Worker(disown_timeout=config.get('disown_timeout', DEFAULT_DISOWN_TIMEOUT))

--- a/src/cocaine-app/monitor_pool.py
+++ b/src/cocaine-app/monitor_pool.py
@@ -1,3 +1,4 @@
+import atexit
 import elliptics
 
 from mastermind.pool import Pool
@@ -27,3 +28,10 @@ monitor_pool = Pool(
     },
     processes=MONITOR_CFG.get('pool_size', 5),
 )
+
+
+@atexit.register
+def stop_pool():
+    """Stop pool workers on main process shutdown"""
+    monitor_pool.close()
+    monitor_pool.join()


### PR DESCRIPTION
Main process should gracefully stop worker pool when SIGTERM
is received, otherwise worker pool processes become orphaned.
