### PR TITLE
Fix snapshot for Backend and FS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mastermind (2.25.36-col) trusty; urgency=medium
+
+  * Fixed snapshot for backends and filesystems
+
+ -- Vladimir Nikulichev <saturnus@yandex-team.ru>  Wed, 19 Nov 2015 20:45:07 +0300
+
 mastermind (2.25.35-col) trusty; urgency=medium
 
   * Inventory

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -889,6 +889,21 @@ void Storage::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
             node.print_json(writer, entries.backends, entries.filesystems,
                     !!(item_types & Filter::Backend), !!(item_types & Filter::FS), show_internals);
         writer.EndArray();
+    } else {
+        if (!entries.backends.empty()) {
+            writer.Key("backends");
+            writer.StartArray();
+            for (Backend & backend : entries.backends)
+                backend.print_json(writer, show_internals);
+            writer.EndArray();
+        }
+        if (!entries.filesystems.empty()) {
+            writer.Key("filesystems");
+            writer.StartArray();
+            for (FS & fs : entries.filesystems)
+                fs.print_json(writer, show_internals);
+            writer.EndArray();
+        }
     }
 
     if (!entries.groups.empty()) {


### PR DESCRIPTION
By default JSON sent in response to snapshot request contains backend and filesystem objects nested to nodes. Their print routines were invoked from `Node::write_json()`. The problem was that when the user requested only backends or filesystems, no `Node` code was executed, so they were ignored.

This changeset adds branch handling this situation.

Note that at now this code is only for testing and troubleshooting, it will be completely reworked as part of development of public interface (JSON schema, request format, etc.).
