### PR TITLE
Mongo queries and weights recounting optimization

### DIFF
--- a/src/cocaine-app/db/mongo/pool.py
+++ b/src/cocaine-app/db/mongo/pool.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import pymongo
 import sys
 import time
 import re
@@ -10,7 +9,6 @@ import traceback
 from copy import deepcopy
 import pymongo
 from pymongo.collection import Collection as OriginalCollection
-from pymongo.errors import ConnectionFailure, OperationFailure, AutoReconnect
 from pymongo.mongo_replica_set_client import MongoReplicaSetClient as MRSC
 
 

--- a/src/cocaine-app/history.py
+++ b/src/cocaine-app/history.py
@@ -52,7 +52,6 @@ class GroupHistory(MongoObject):
 
     @classmethod
     def new(cls, **kwargs):
-        super(GroupHistory, cls).new(**kwargs)
         group_history = cls(**kwargs)
         group_history._dirty = True
         return group_history
@@ -273,7 +272,7 @@ class GroupHistoryFinder(object):
             .limit(1)
         )
         try:
-            group_history = GroupHistory.new(**group_history_list[0])
+            group_history = GroupHistory(**group_history_list[0])
         except IndexError:
             raise GroupHistoryNotFoundError(
                 'Group history for group {} is not found'.format(group_id)

--- a/src/cocaine-app/history.py
+++ b/src/cocaine-app/history.py
@@ -272,11 +272,12 @@ class GroupHistoryFinder(object):
             .list(group_id=group_id)
             .limit(1)
         )
-        if not group_history_list.count():
+        try:
+            group_history = GroupHistory.new(**group_history_list[0])
+        except IndexError:
             raise GroupHistoryNotFoundError(
                 'Group history for group {} is not found'.format(group_id)
             )
-        group_history = GroupHistory.new(**group_history_list[0])
         group_history.collection = self.collection
         return group_history
 

--- a/src/cocaine-app/history.py
+++ b/src/cocaine-app/history.py
@@ -299,6 +299,13 @@ class GroupHistoryFinder(object):
             gh._dirty = False
         return group_histories
 
+    def search_by_group_ids(self, group_ids):
+        group_history_records = self.collection.find({'group_id': {'$in': group_ids}})
+        for group_history_record in group_history_records:
+            gh = GroupHistory(**group_history_record)
+            gh.collection = self.collection
+            yield gh
+
     def search_by_node_backend(self,
                                hostname=None,
                                port=None,

--- a/src/cocaine-app/infrastructure.py
+++ b/src/cocaine-app/infrastructure.py
@@ -240,7 +240,7 @@ class Infrastructure(object):
             self._groups_to_update.add(group)
 
     def _new_group_history(self, group_id):
-        gh = GroupHistory(group_id=group_id)
+        gh = GroupHistory.new(group_id=group_id)
         gh.collection = self.group_history_finder.collection
         return gh
 

--- a/src/cocaine-app/node_info_updater.py
+++ b/src/cocaine-app/node_info_updater.py
@@ -152,6 +152,7 @@ class NodeInfoUpdater(object):
         )
         logger.info('Waiting for monitor stats results')
 
+        # TODO: set timeout!!!
         for packed_result in skip_exceptions(results,
                                              on_exc=NodeInfoUpdater.log_monitor_stat_exc):
             try:
@@ -233,6 +234,7 @@ class NodeInfoUpdater(object):
                 elapsed_time=result['request_time']
             )
 
+        # TODO: can we use iterkeys?
         nbs = (groups and
                [nb for g in groups for nb in g.node_backends] or
                storage.node_backends.keys())
@@ -240,6 +242,7 @@ class NodeInfoUpdater(object):
             nb.update_statistics_status()
             nb.update_status()
 
+        # TODO: can we use iterkeys?
         fss = (groups and set(nb.fs for nb in nbs) or storage.fs.keys())
         for fs in fss:
             fs.update_status()

--- a/src/cocaine-app/node_info_updater.py
+++ b/src/cocaine-app/node_info_updater.py
@@ -543,10 +543,11 @@ class NodeInfoUpdater(object):
                         logger.exception('Failed to update group {0} status: {1}'.format(group, e))
                         pass
 
-            load_manager.update(storage)
-            weight_manager.update(storage)
+            if groups is None:
+                load_manager.update(storage)
+                weight_manager.update(storage)
 
-            infrastructure.schedule_history_update()
+                infrastructure.schedule_history_update()
 
         except Exception as e:
             logger.exception('Critical error during symmetric group update')

--- a/src/cocaine-app/node_info_updater.py
+++ b/src/cocaine-app/node_info_updater.py
@@ -278,6 +278,99 @@ class NodeInfoUpdater(object):
         return parsed_stats
 
     @staticmethod
+    def _process_backend_statistics(node,
+                                    b_stat,
+                                    backend_stats,
+                                    collect_ts,
+                                    processed_fss,
+                                    processed_node_backends):
+
+        backend_id = b_stat['backend_id']
+
+        nb_config = (b_stat['config']
+                     if 'config' in b_stat else
+                     b_stat['backend']['config'])
+        gid = nb_config['group']
+
+        if gid == 0:
+            # skip zero group ids
+            return
+
+        b_stat['stats'] = backend_stats.get(backend_id, {})
+
+        update_group_history = False
+
+        node_backend_addr = '{0}/{1}'.format(node, backend_id)
+        if node_backend_addr not in storage.node_backends:
+            node_backend = storage.node_backends.add(node, backend_id)
+            update_group_history = True
+        else:
+            node_backend = storage.node_backends[node_backend_addr]
+
+        if b_stat['status']['state'] != 1:
+            logger.info('Node backend {0} is not enabled: state {1}'.format(
+                str(node_backend), b_stat['status']['state']))
+            node_backend.disable()
+            return
+
+        node_backend.enable()
+
+        if gid not in storage.groups:
+            logger.debug('Adding group {0}'.format(gid))
+            group = storage.groups.add(gid)
+        else:
+            group = storage.groups[gid]
+
+        fsid = b_stat['backend']['vfs']['fsid']
+        fsid_key = '{host}:{fsid}'.format(host=node.host, fsid=fsid)
+
+        if fsid_key not in storage.fs:
+            logger.debug('Adding fs {0}'.format(fsid_key))
+            fs = storage.fs.add(node.host, fsid)
+        else:
+            fs = storage.fs[fsid_key]
+
+        if node_backend not in fs.node_backends:
+            fs.add_node_backend(node_backend)
+
+        if fs not in processed_fss:
+            fs.update_statistics(b_stat['backend'], collect_ts)
+            processed_fss.add(fs)
+
+        logger.info('Updating statistics for node backend {}'.format(node_backend))
+        prev_base_path = node_backend.base_path
+        try:
+            node_backend.update_statistics(b_stat, collect_ts)
+        except KeyError as e:
+            logger.warn('Bad stat for node backend {0} ({1}): {2}'.format(
+                node_backend, e, b_stat))
+            pass
+
+        if node_backend.base_path != prev_base_path:
+            update_group_history = True
+
+        if b_stat['status']['read_only'] or node_backend.stat_commit_errors > 0:
+            node_backend.make_read_only()
+        else:
+            node_backend.make_writable()
+
+        if node_backend.group is not group:
+            logger.debug('Adding node backend {0} to group {1}{2}'.format(
+                node_backend, group.group_id,
+                ' (moved from group {0})'.format(node_backend.group.group_id)
+                if node_backend.group else ''))
+            group.add_node_backend(node_backend)
+            update_group_history = True
+
+        # these backends' commands stat are used later to update accumulated
+        # node commands stat
+        processed_node_backends.append(node_backend)
+
+        if update_group_history:
+            logger.debug('Group {} history may be outdated, adding to update queue'.format(group))
+            infrastructure.update_group_history(group)
+
+    @staticmethod
     def update_statistics(node, stat, elapsed_time=None):
 
         logger.debug(
@@ -301,103 +394,33 @@ class NodeInfoUpdater(object):
             backend_stats = NodeInfoUpdater._parsed_stats(stat['stats'])
 
             for b_stat in stat['backends'].itervalues():
-                backend_id = b_stat['backend_id']
-                b_stat['stats'] = backend_stats.get(backend_id, {})
-
-                update_group_history = False
-
-                node_backend_addr = '{0}/{1}'.format(node, backend_id)
-                if node_backend_addr not in storage.node_backends:
-                    node_backend = storage.node_backends.add(node, backend_id)
-                    update_group_history = True
-                else:
-                    node_backend = storage.node_backends[node_backend_addr]
-
-                nb_config = (b_stat['config']
-                             if 'config' in b_stat else
-                             b_stat['backend']['config'])
-
-                gid = nb_config['group']
-
-                if gid == 0:
-                    # skip zero group ids
-                    continue
-
-                if b_stat['status']['state'] != 1:
-                    logger.info('Node backend {0} is not enabled: state {1}'.format(
-                        str(node_backend), b_stat['status']['state']))
-                    node_backend.disable()
-                    continue
-
-                if gid not in storage.groups:
-                    logger.debug('Adding group {0}'.format(gid))
-                    group = storage.groups.add(gid)
-                else:
-                    group = storage.groups[gid]
-
-                if 'vfs' not in b_stat['backend']:
-                    logger.error(
-                        'Failed to parse statistics for node backend {0}, '
-                        'vfs key not found: {1}'.format(node_backend, b_stat))
-                    continue
-
-                fsid = b_stat['backend']['vfs']['fsid']
-                fsid_key = '{host}:{fsid}'.format(host=node.host, fsid=fsid)
-
-                if fsid_key not in storage.fs:
-                    logger.debug('Adding fs {0}'.format(fsid_key))
-                    fs = storage.fs.add(node.host, fsid)
-                else:
-                    fs = storage.fs[fsid_key]
-
-                if node_backend not in fs.node_backends:
-                    fs.add_node_backend(node_backend)
-                fs.update_statistics(b_stat['backend'], collect_ts)
-
-                fss.add(fs)
-                good_node_backends.append(node_backend)
-
-                node_backend.enable()
-
-                logger.info('Updating statistics for node backend %s' % (str(node_backend)))
-                if 'backend' not in b_stat:
-                    logger.warn('No backend in b_stat: {0}'.format(b_stat))
-                elif 'dstat' not in b_stat['backend']:
-                    logger.warn('No dstat in backend: {0}'.format(b_stat['backend']))
-
-                prev_base_path = node_backend.base_path
                 try:
-                    node_backend.update_statistics(b_stat, collect_ts)
-                except KeyError as e:
-                    logger.warn('Bad stat for node backend {0} ({1}): {2}'.format(
-                        node_backend, e, b_stat))
-                    pass
+                    NodeInfoUpdater._process_backend_statistics(
+                        node,
+                        b_stat,
+                        backend_stats,
+                        collect_ts,
+                        fss,
+                        good_node_backends
+                    )
+                except Exception:
+                    backend_id = b_stat['backend_id']
+                    logger.exception(
+                        'Failed to process backend {} stats on node {}'.format(backend_id, node)
+                    )
+                    continue
 
-                if node_backend.base_path != prev_base_path:
-                    update_group_history = True
-
-                if b_stat['status']['read_only'] or node_backend.stat_commit_errors > 0:
-                    node_backend.make_read_only()
-                else:
-                    node_backend.make_writable()
-
-                if node_backend.group is not group:
-                    logger.debug('Adding node backend {0} to group {1}{2}'.format(
-                        node_backend, group.group_id,
-                        ' (moved from group {0})'.format(node_backend.group.group_id)
-                        if node_backend.group else ''))
-                    update_group_history = True
-                    group.add_node_backend(node_backend)
-
-                if update_group_history:
-                    infrastructure.update_group_history(group)
-
+            logger.debug('Cluster updating: node {}, updating FS commands stats'.format(node))
             for fs in fss:
                 fs.update_commands_stats()
+
+            logger.debug('Cluster updating: node {}, updating node commands stats'.format(node))
             node.update_commands_stats(good_node_backends)
 
         except Exception as e:
             logger.exception('Unable to process statistics for node {}'.format(node))
+        finally:
+            logger.debug('Cluster updating: node {}, statistics processed'.format(node))
 
     def update_symm_groups_async(self, groups=None):
 

--- a/src/cocaine-app/storage.py
+++ b/src/cocaine-app/storage.py
@@ -321,6 +321,7 @@ class CommandsStat(object):
 
 class NodeBackendStat(object):
     def __init__(self, node_stat):
+        # TODO: not required anymore, remove (?)
         self.node_stat = node_stat
         self.ts = None
 
@@ -768,6 +769,10 @@ class Fs(object):
             self.status = Status.BROKEN
         else:
             self.status = Status.OK
+
+        # TODO: unwind cycle dependency between node backend status and fs
+        # status. E.g., check node backend status and file system status
+        # separately on group status updating.
 
         if self.status != prev_status:
             logger.info('Changing status of fs {0}, affecting node backends {1}'.format(

--- a/src/cocaine-app/weight_manager.py
+++ b/src/cocaine-app/weight_manager.py
@@ -89,6 +89,8 @@ class WeightManager(object):
                     ns_weights.setdefault(len(couple.groups), [])
                     if couple.status != storage.Status.OK:
                         continue
+                    if couple not in self.couples:
+                        continue
                     ns_sizes.setdefault(len(couple.groups), []).append(self.couples[couple])
 
                 required_units = WeightCalculator.ns_used_resources(ns)

--- a/src/python-mastermind/src/mastermind/pool.py
+++ b/src/python-mastermind/src/mastermind/pool.py
@@ -44,6 +44,7 @@ implementation changes.
 from collections import Iterator
 from datetime import timedelta
 import logging
+from multiprocessing import TimeoutError
 from multiprocessing.pool import Pool as OriginalPool
 from multiprocessing.queues import SimpleQueue as OriginalSimpleQueue
 from multiprocessing.queues import Empty
@@ -296,14 +297,16 @@ class SimpleQueue(OriginalSimpleQueue):
         self.get = get
 
 
-def skip_exceptions(result, on_exc=None):
+def skip_exceptions(result, on_exc=None, timeout=None):
     if not isinstance(result, Iterator):
         raise TypeError('Iterator object is expected')
 
     while True:
         try:
-            yield result.next()
+            yield result.next(timeout)
         except StopIteration:
+            raise
+        except TimeoutError:
             raise
         except Exception as e:
             if on_exc:


### PR DESCRIPTION
Since there are cases when we need to fetch hundreds
of thousands mongo db rows, one row fetching at a time
results in very poor timings. Fetching all history
records in a single query gives tremendous x10-x100 speed boost.

Some other minor fixes are included, see commit list.
