### PR TITLE
Fix miss of job on group with no enabled backends

### DIFF
--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -56,15 +56,19 @@ void Couple::update_status()
     for (const Group & group : m_groups) {
         if (!group.get_metadata().version) {
             m_status = BAD;
-            ostr << "Group " << group.get_id() << " has empty metadata.";
-            m_status_text = ostr.str();
+            if (!account_job_in_status()) {
+                ostr << "Group " << group.get_id() << " has empty metadata.";
+                m_status_text = ostr.str();
+            }
             return;
         }
         if (m_namespace.get().get_id() != group.get_metadata().namespace_name) {
             m_status = BAD;
-            ostr << "Couple's namespace '" << m_namespace.get().get_id() << "' doesn't match group's "
-                    "namespace '" << group.get_metadata().namespace_name << "'.";
-            m_status_text = ostr.str();
+            if (!account_job_in_status()) {
+                ostr << "Couple's namespace '" << m_namespace.get().get_id() << "' doesn't match group's "
+                        "namespace '" << group.get_metadata().namespace_name << "'.";
+                m_status_text = ostr.str();
+            }
             return;
         }
     }

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -118,6 +118,8 @@ groups.
   https://github.com/yandex/mastermind/issues/31.
   11. TODO: add separate test for `account_job_in_status()` in the same way as
   for DC sharing.
+  12. *Job #1*. Group has no enabled backends, but have `PENDING`
+  `MOVE_JOB`. Result: `SERVICE_STALLED`.
 * **Namespace without settings**. This test checks whether Couple is reported
   `BROKEN` when no namespace settings found.
   1. *Correct setup*. Having couple in namespace which is set up


### PR DESCRIPTION
When a group had no backends, job wasn't taken into account. As a result, state of the couple was set to `BAD` instead of `SERVICE_ACTIVE`/`SERVICE_STALLED`.
