### PR TITLE
MDS-1966: Backend queue statistics

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -66,7 +66,9 @@ BackendStat::BackendStat()
     ell_cache_read_size(0),
     ell_cache_read_time(0),
     ell_disk_read_size(0),
-    ell_disk_read_time(0)
+    ell_disk_read_time(0),
+    io_blocking_size(0),
+    io_nonblocking_size(0)
 {}
 
 CommandStat::CommandStat()
@@ -360,6 +362,8 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     //     "free_space": 3035659162,
     //     "fsid": 8323278684798404738,
     //     "group": 83,
+    //     "io_blocking_size": 0,
+    //     "io_nonblocking_size": 0,
     //     "last_start": {
     //         "ts_sec": 1444498430,
     //         "ts_usec": 864588

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -85,6 +85,10 @@ struct BackendStat
     uint64_t ell_disk_read_size;
     uint64_t ell_disk_read_time;
 
+    // TODO: Use handystats counters.
+    uint64_t io_blocking_size;
+    uint64_t io_nonblocking_size;
+
     std::string data_path;
     std::string file_path;
 };

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -494,7 +494,7 @@ CURL *Round::create_easy_handle(Node *node)
     url << "http://" << node->get_host().get_addr() << ':'
         << app::config().monitor_port << "/?categories="
         << uint32_t(DNET_MONITOR_PROCFS | DNET_MONITOR_BACKEND |
-                DNET_MONITOR_STATS | DNET_MONITOR_COMMANDS);
+                DNET_MONITOR_STATS | DNET_MONITOR_COMMANDS | DNET_MONITOR_IO);
 
     curl_easy_setopt(easy, CURLOPT_URL, url.str().c_str());
     curl_easy_setopt(easy, CURLOPT_PRIVATE, node);

--- a/src/collector/StatsParser.cpp
+++ b/src/collector/StatsParser.cpp
@@ -77,6 +77,11 @@ const uint64_t Backends                           = 2ULL;
                     const uint64_t CommandSource  = 0x800ULL;
                         const uint64_t Size       = 0x1000ULL;
                         const uint64_t Time       = 0x2000ULL;
+        const uint64_t Io                         = 0x80ULL;
+            const uint64_t Blocking               = 0x100ULL;
+//                             CurrentSize        = 0x400ULL;
+            const uint64_t Nonblocking            = 0x200ULL;
+                const uint64_t CurrentSize        = 0x400ULL;
 
 const uint64_t Timestamp  = 4ULL;
     const uint64_t TvSec  = 8ULL;
@@ -117,6 +122,7 @@ std::vector<Parser::FolderVector> backend_folders = {
         { "backend_id",     Backends|BackendFolder, BackendId     },
         { "status",         Backends|BackendFolder, Status        },
         { "commands",       Backends|BackendFolder, Commands      },
+        { "io",             Backends|BackendFolder, Io            },
         { "la",             Procfs|Vm,              La            },
         { "net_interfaces", Procfs|Net,             NetInterfaces },
         { "count",          Stats|StatName,         Count         }
@@ -133,6 +139,8 @@ std::vector<Parser::FolderVector> backend_folders = {
         { "last_start",      Backends|BackendFolder|Status,   LastStart        },
         { "WRITE",           Backends|BackendFolder|Commands, Write            },
         { NOT_MATCH "WRITE", Backends|BackendFolder|Commands, NotWrite         },
+        { "blocking",        Backends|BackendFolder|Io,       Blocking         },
+        { "nonblocking",     Backends|BackendFolder|Io,       Nonblocking      },
         { NOT_MATCH "lo",    Procfs|Net|NetInterfaces,        NetInterfaceName }
     },
     {
@@ -165,6 +173,8 @@ std::vector<Parser::FolderVector> backend_folders = {
         { "disk",                 Backends|BackendFolder|Commands|Write,       Disk               },
         { "cache",                Backends|BackendFolder|Commands|NotWrite,    Cache              },
         { "disk",                 Backends|BackendFolder|Commands|NotWrite,    Disk               },
+        { "current_size",         Backends|BackendFolder|Io|Blocking,          CurrentSize        },
+        { "current_size",         Backends|BackendFolder|Io|Nonblocking,       CurrentSize        },
         { "receive",              Procfs|Net|NetInterfaces|NetInterfaceName,   Receive            },
         { "transmit",             Procfs|Net|NetInterfaces|NetInterfaceName,   Transmit           }
     },
@@ -229,6 +239,8 @@ Parser::UIntInfoVector backend_uint_info = {
     { Backends|BackendFolder|Commands|NotWrite|Cache|CommandSource|Time,  SUM, BOFF(ell_cache_read_time)  },
     { Backends|BackendFolder|Commands|NotWrite|Disk|CommandSource|Size,   SUM, BOFF(ell_disk_read_size)   },
     { Backends|BackendFolder|Commands|NotWrite|Disk|CommandSource|Time,   SUM, BOFF(ell_disk_read_time)   },
+    { Backends|BackendFolder|Io|Blocking|CurrentSize,                     SET, BOFF(io_blocking_size)     },
+    { Backends|BackendFolder|Io|Nonblocking|CurrentSize,                  SET, BOFF(io_nonblocking_size)  },
     { Timestamp|TvSec,                                                    SET, NOFF(ts_sec)               },
     { Timestamp|TvUsec,                                                   SET, NOFF(ts_usec)              },
     { Procfs|Vm|La,                                                       SET, NOFF(la1)                  },


### PR DESCRIPTION
DNET_MONITOR_IO statistic contains queue lengths:

"io": {
  "blocking": {
    "current_size": 0
  },
  "nonblocking": {
    "current_size": 0
  }
}

They appear as 'io_blocking_size' and 'io_nonblocking_size' in backend JSON.
