### PR TITLE
Use CLOCK_REALTIME

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -244,7 +244,7 @@ void Backend::recalculate()
 void Backend::check_stalled()
 {
     uint64_t ts_now = 0;
-    clock_get(ts_now);
+    clock_get_real(ts_now);
     ts_now /= 1000000000ULL;
 
     if (ts_now <= m_stat.ts_sec) {


### PR DESCRIPTION
In `Backend::check_stalled()` we took the value of timer `CLOCK_MONOTONIC` and compared it against timestamp coming from Elliptics monitor_stats. It is obviously wrong, we must use `CLOCK_REALTIME`. This simple commit fixes the bug.
