### PR TITLE
Fix couple check

### DIFF
--- a/src/collector/Couple.cpp
+++ b/src/collector/Couple.cpp
@@ -195,8 +195,8 @@ bool Couple::check_groups(const std::vector<int> & group_ids) const
     if (group_ids.size() != m_groups.size())
         return false;
 
-    for (size_t i = 0; i < group_ids.size(); ++i) {
-        if (m_groups[i].get().get_id() != group_ids[i])
+    for (const Group & group : m_groups) {
+        if (group.get_metadata().couple != group_ids)
             return false;
     }
 

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -206,6 +206,11 @@ groups.
   of backends. List of Group's backends must become empty.
   6. *Automatic history entries*. Make sure entries of type `automatic`
   are getting skipped.
+* **Couple check (issue #97)**. Example setup: there are groups 5, 11, 12.
+  They all have coupling info (5, 11, 12) in metadata. These groups are
+  in state `COUPLED`, and couple 5:11:12 is in state `OK`. Then we receive
+  metadata of group 10 which is (10, 11, 12). After couple check group 10
+  must become `BAD`.
 
 #### Filesystem:
 


### PR DESCRIPTION
This makes Couple::check_groups() work in the same way as in Python
cocaine worker.
