### PR TITLE
Do not apply outdated history entries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/collector/googletest"]
 	path = tests/collector/googletest
-	url = https://github.com/google/googletest
+	url = git://github.com/google/googletest.git

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -19,6 +19,7 @@
 #ifndef __046c58ff_e6c4_49a6_a920_eee87b111685
 #define __046c58ff_e6c4_49a6_a920_eee87b111685
 
+#include <blackhole/attribute.hpp>
 #include <functional>
 #include <iostream>
 #include <rapidjson/writer.h>
@@ -170,6 +171,8 @@ private:
 
 private:
     int m_id;
+
+    blackhole::log::attributes_t m_attr;
 
     // Set of references to backends serving this group. They shouldn't be
     // modified directly but only used to obtain related items and calculate the

--- a/src/collector/Node.h
+++ b/src/collector/Node.h
@@ -21,6 +21,7 @@
 
 #include "Backend.h"
 
+#include <blackhole/attribute.hpp>
 #include <functional>
 #include <map>
 #include <rapidjson/writer.h>
@@ -138,6 +139,8 @@ private:
     int m_port;
     int m_family;
     std::string m_key;
+
+    blackhole::log::attributes_t m_attr;
 
     // backend and procfs statistics downloaded using HTTP
     std::string m_download_data;

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -154,6 +154,11 @@ void Round::step2_1_jobs_and_history(void *arg)
 
     Stopwatch watch(self.m_clock.mongo);
 
+    // This is an approximate point of time we started collecting statistics.
+    // It will be used to filter history entries.
+    uint64_t start_ts = 0;
+    clock_get_real(start_ts);
+
     try {
         const Config & config = app::config();
 
@@ -229,9 +234,11 @@ void Round::step2_1_jobs_and_history(void *arg)
 
         // History
 
-        uint64_t group_history_ts = 0;
-        clock_get_real(group_history_ts);
-        double previous_ts = self.m_storage->get_group_history_ts() / 1000000000ULL;
+        double previous_ts;
+        if (self.m_storage->get_group_history_ts() > 0)
+            previous_ts = self.m_storage->get_group_history_ts() / 1000000000ULL;
+        else
+            previous_ts = start_ts / 1000000000ULL;
 
         std::vector<GroupHistoryEntry> group_history;
 
@@ -267,7 +274,7 @@ void Round::step2_1_jobs_and_history(void *arg)
 
         BH_LOG(app::logger(), DNET_LOG_INFO, "Loaded %lu group history entries", group_history.size());
 
-        self.m_storage->save_group_history(std::move(group_history), group_history_ts);
+        self.m_storage->save_group_history(std::move(group_history), start_ts);
 
     } catch (const mongo::DBException & e) {
         BH_LOG(app::logger(), DNET_LOG_ERROR,

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -138,16 +138,22 @@ void Storage::add_node(const Host & host, int port, int family)
 
 void Storage::handle_backend(Backend & backend)
 {
+    BH_LOG(app::logger(), DNET_LOG_DEBUG, "Storage: Handle backend %s", backend.get_key());
+
     auto it = m_groups.lower_bound(backend.get_stat().group);
 
     if (it != m_groups.end() && it->first == int(backend.get_stat().group)) {
+        BH_LOG(app::logger(), DNET_LOG_DEBUG, "Adding backend to group %lu", backend.get_stat().group);
         it->second.add_backend(backend);
     } else {
+        BH_LOG(app::logger(), DNET_LOG_DEBUG, "New group %lu", backend.get_stat().group);
         it = m_groups.insert(it, std::make_pair(backend.get_stat().group, Group(backend.get_stat().group)));
         it->second.add_backend(backend);
     }
 
     if (backend.group_changed()) {
+        BH_LOG(app::logger(), DNET_LOG_DEBUG, "Backend group changed");
+
         int old_id = backend.get_old_group_id();
         auto it_old = m_groups.find(old_id);
         if (it_old != m_groups.end()) {

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -97,7 +97,7 @@ Storage::Storage()
 Storage::Storage(const Storage & other)
     :
     m_jobs_timestamp(0),
-    m_group_history_ts(0)
+    m_group_history_ts(other.m_group_history_ts)
 {
     bool have_newer;
     merge(other, have_newer);
@@ -215,13 +215,6 @@ void Storage::update_group_structure()
 {
     BH_LOG(app::logger(), DNET_LOG_INFO, "Updating group structure");
 
-    for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it) {
-        Node & node = it->second;
-        std::vector<std::reference_wrapper<Backend>> backends = node.pick_new_backends();
-        for (Backend & backend : backends)
-            handle_backend(backend);
-    }
-
     for (const GroupHistoryEntry & entry : m_group_history) {
         auto it = m_groups.find(entry.get_group_id());
         if (it != m_groups.end()) {
@@ -230,6 +223,13 @@ void Storage::update_group_structure()
             BH_LOG(app::logger(), DNET_LOG_DEBUG, "History database contains record for "
                     "unknown group %d", entry.get_group_id());
         }
+    }
+
+    for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it) {
+        Node & node = it->second;
+        std::vector<std::reference_wrapper<Backend>> backends = node.pick_new_backends();
+        for (Backend & backend : backends)
+            handle_backend(backend);
     }
 }
 

--- a/tests/TODO.md
+++ b/tests/TODO.md
@@ -252,6 +252,8 @@ groups.
   then with one incorrect (lacking fields/wrong field type).
   6. *Two and three nodes*. Try 2 and 3 audit records and check whether
   the most recent record is selected.
+  7. *Old entry*. History contains old entries with empty set of backends.
+  Group has enabled backend. Old entries shouldn't affect the current state.
 
 #### Inventory:
 * **TODO**: Primarily tests should cover communication with MongoDB,


### PR DESCRIPTION
This fixes a situation when backends are enabled in Elliptics but being unbound
from group in accordance with old history entries. It happened because filter
in history database query always contained zero timestamp.

1) In first round history entries are filtered with current timestamp;
2) fixed loss of Storage::m_group_history_ts in copy constructor;
3) history is now processed before handling new backends.
