### PR TITLE
Basic tests for Group

### DIFF
--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -181,10 +181,10 @@ void Group::save_metadata(const char *metadata, size_t size, uint64_t timestamp)
     m_clean = false;
 }
 
-int Group::parse_metadata()
+bool Group::parse_metadata()
 {
     if (m_clean)
-        return 0;
+        return true;
 
     m_clean = true;
     m_metadata_parsed = false;
@@ -209,7 +209,7 @@ int Group::parse_metadata()
     if (!ostr.str().empty()) {
         m_status_text = ostr.str();
         m_status = BAD;
-        return -1;
+        return false;
     }
 
     int version = 0;
@@ -320,7 +320,7 @@ int Group::parse_metadata()
         m_status_text = ostr.str();
         m_status = BAD;
         BH_LOG(app::logger(), DNET_LOG_ERROR, "Metadata parse error: %s", m_status_text.c_str());
-        return -1;
+        return false;
     }
 
     m_metadata.version = version;
@@ -332,7 +332,7 @@ int Group::parse_metadata()
     m_metadata.service.job_id = service_job_id;
     m_metadata_parsed = true;
 
-    return 0;
+    return true;
 }
 
 void Group::calculate_type()

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -124,7 +124,7 @@ public:
 
     void handle_metadata_download_failed(const std::string & why);
     void save_metadata(const char *metadata, size_t size, uint64_t timestamp);
-    int parse_metadata();
+    bool parse_metadata();
     void calculate_type();
 
     bool metadata_parsed() const

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -83,7 +83,6 @@ public:
 
 public:
     Group(int id);
-    Group();
 
     int get_id() const
     { return m_id; }

--- a/src/collector/Group.h
+++ b/src/collector/Group.h
@@ -31,8 +31,10 @@
 class Backend;
 class Couple;
 class Filter;
+class FS;
 class GroupHistoryEntry;
 class Namespace;
+class Node;
 class Storage;
 
 class Group

--- a/src/collector/Storage.cpp
+++ b/src/collector/Storage.cpp
@@ -264,7 +264,7 @@ void Storage::update()
         else
             group.set_active_job(jit->second);
 
-        if (group.parse_metadata() != 0)
+        if (!group.parse_metadata())
             continue;
 
         group.calculate_type();

--- a/tests/collector/CMakeLists.txt
+++ b/tests/collector/CMakeLists.txt
@@ -30,3 +30,4 @@ set(TEST_LIBRARIES
 add_subdirectory(config_parser)
 add_subdirectory(filter_parser)
 add_subdirectory(stats_parser)
+add_subdirectory(group)

--- a/tests/collector/group/CMakeLists.txt
+++ b/tests/collector/group/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(group group.cpp)
+
+target_link_libraries(group ${TEST_LIBRARIES})
+
+add_dependencies(group ${GTEST_TARGETS})
+
+add_test(group group)
+add_dependencies(run_tests group)

--- a/tests/collector/group/group.cpp
+++ b/tests/collector/group/group.cpp
@@ -1,0 +1,172 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library.
+*/
+
+#include <Group.h>
+
+#include <msgpack.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+} // unnamed namespace
+
+TEST(Group, Ctor)
+{
+    // This test checks initialization of Group object.
+
+    Group g(0);
+
+    g.~Group();
+    // Write junk bytes and check members initialization afterwards.
+    memset(&g, 0x5a, sizeof(g));
+    new (&g) Group(113);
+
+    EXPECT_EQ(113, g.get_id());
+    EXPECT_TRUE(g.get_backends().empty());
+    EXPECT_EQ(0, g.get_update_time());
+    EXPECT_FALSE(g.has_active_job());
+
+    const Group::Metadata & md = g.get_metadata();
+    EXPECT_EQ(0, md.version);
+    EXPECT_FALSE(md.frozen);
+    EXPECT_TRUE(md.couple.empty());
+    EXPECT_TRUE(md.namespace_name.empty());
+    EXPECT_TRUE(md.type.empty());
+    EXPECT_FALSE(md.service.migrating);
+    EXPECT_TRUE(md.service.job_id.empty());
+
+    EXPECT_FALSE(g.metadata_parsed());
+    EXPECT_EQ(0, g.get_metadata_parse_duration());
+
+    EXPECT_EQ(Group::DATA, g.get_type());
+    EXPECT_EQ(Group::INIT, g.get_status());
+}
+
+TEST(Group, ParseMetadataV1)
+{
+    // This test checks metadata parsing for version 1 metadata
+    // which is msgpack:ed array of groups in couple.
+
+    // Prepare metadata.
+
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> packer(&buffer);
+    packer.pack_array(3);
+    packer.pack(17);
+    packer.pack(19);
+    packer.pack(23);
+
+    // Create group and parse metadata.
+
+    Group g(17);
+    g.save_metadata(buffer.data(), buffer.size(), ::time(nullptr)*1000000000ULL);
+    ASSERT_TRUE(g.parse_metadata());
+    EXPECT_TRUE(g.metadata_parsed());
+
+    // Check metadata values.
+
+    const Group::Metadata & md = g.get_metadata();
+    EXPECT_EQ(1, md.version);
+    EXPECT_FALSE(md.frozen);
+    EXPECT_EQ(std::vector<int>({17, 19, 23}), md.couple);
+    EXPECT_EQ("default", md.namespace_name);
+    EXPECT_TRUE(md.type.empty());
+    EXPECT_FALSE(md.service.migrating);
+    EXPECT_TRUE(md.service.job_id.empty());
+
+    // Check if type and status weren't affected.
+
+    g.calculate_type();
+
+    EXPECT_EQ(Group::DATA, g.get_type());
+    EXPECT_EQ(Group::INIT, g.get_status());
+
+    // Check that other values didn't change.
+
+    EXPECT_EQ(17, g.get_id());
+    EXPECT_TRUE(g.get_backends().empty());
+    EXPECT_FALSE(g.has_active_job());
+}
+
+TEST(Group, ParseMetadataV2)
+{
+    // This test checks metadata parsing for version 2
+    // metadata which is msgpack:ed map.
+
+    // Prepare metadata.
+
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> packer(&buffer);
+    packer.pack_map(6);
+
+    packer.pack(std::string("version"));
+    packer.pack(2);
+
+    packer.pack(std::string("frozen"));
+    packer.pack(true);
+
+    packer.pack(std::string("couple"));
+    packer.pack_array(3);
+    packer.pack(29);
+    packer.pack(31);
+    packer.pack(37);
+
+    packer.pack(std::string("namespace"));
+    packer.pack(std::string("storage"));
+
+    packer.pack(std::string("type"));
+    packer.pack(std::string("cache"));
+
+    packer.pack(std::string("service"));
+    packer.pack_map(2);
+    packer.pack(std::string("status"));
+    packer.pack(std::string("MIGRATING"));
+    packer.pack(std::string(std::string("job_id")));
+    packer.pack(std::string("12345"));
+
+    // Create group and parse metadata.
+
+    Group g(29);
+    g.save_metadata(buffer.data(), buffer.size(), ::time(nullptr)*1000000000ULL);
+    ASSERT_TRUE(g.parse_metadata());
+    EXPECT_TRUE(g.metadata_parsed());
+
+    // Check metadata values.
+
+    const Group::Metadata & md = g.get_metadata();
+    EXPECT_EQ(2, md.version);
+    EXPECT_TRUE(md.frozen);
+    EXPECT_EQ(std::vector<int>({29, 31, 37}), md.couple);
+    EXPECT_EQ("storage", md.namespace_name);
+    EXPECT_EQ("cache", md.type);
+    EXPECT_TRUE(md.service.migrating);
+    EXPECT_EQ("12345", md.service.job_id);
+
+    // Check whether the type is taken into account.
+
+    g.calculate_type();
+
+    EXPECT_EQ(Group::CACHE, g.get_type());
+    EXPECT_EQ(Group::INIT, g.get_status());
+
+    // Check that other values didn't change.
+
+    EXPECT_EQ(29, g.get_id());
+    EXPECT_TRUE(g.get_backends().empty());
+    EXPECT_FALSE(g.has_active_job());
+}


### PR DESCRIPTION
This contains three basic tests for `Group`:
- **Ctor**. Make sure that constructor initializes all members.
- **ParseMetadataV1**. Generate msgpack buffer and check if it is parsed correctly. Metadata of version 1 contains array of integers -- group ids in a couple.
- **ParseMetadataV2**. The same as for V1, but parsing metadata version 2 format (dictionary).
