### PR TITLE
Simulated timer for tests

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -243,8 +243,7 @@ void Backend::recalculate()
 
 void Backend::check_stalled()
 {
-    uint64_t ts_now = 0;
-    clock_get_real(ts_now);
+    uint64_t ts_now = clock_get_real();
     ts_now /= 1000000000ULL;
 
     if (ts_now <= m_stat.ts_sec) {

--- a/src/collector/CMakeLists.txt
+++ b/src/collector/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(collector_common STATIC ${COLLECTOR_SOURCES_COMMON})
 target_link_libraries(collector_common ${COLLECTOR_LIBRARIES})
 
 add_executable(mastermind-collector
+    Clock.cpp
     WorkerApplication.cpp
     main.cpp
     )

--- a/src/collector/Clock.cpp
+++ b/src/collector/Clock.cpp
@@ -1,0 +1,26 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "Metrics.h"
+
+uint64_t clock_get_real()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (ts.tv_sec * 1000000000ULL + ts.tv_nsec);
+}

--- a/src/collector/Group.cpp
+++ b/src/collector/Group.cpp
@@ -169,7 +169,7 @@ void Group::apply(const GroupHistoryEntry & entry)
         if (double(m_update_time) < entry.get_timestamp())
             m_update_time = entry.get_timestamp();
         else
-            clock_get_real(m_update_time);
+            m_update_time = clock_get_real();
     }
 }
 
@@ -191,7 +191,7 @@ void Group::save_metadata(const char *metadata, size_t size, uint64_t timestamp)
             !std::memcmp(&m_metadata_file[0], metadata, size))
         return;
 
-    clock_get_real(m_update_time);
+    m_update_time = clock_get_real();
     m_metadata_file.assign(metadata, metadata + size);
     m_clean = false;
 }

--- a/src/collector/Metrics.h
+++ b/src/collector/Metrics.h
@@ -66,12 +66,7 @@ inline void clock_get(uint64_t & value)
     value = ts.tv_sec * 1000000000 + ts.tv_nsec;
 }
 
-inline void clock_get_real(uint64_t & value)
-{
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
-    value = ts.tv_sec * 1000000000 + ts.tv_nsec;
-}
+uint64_t clock_get_real();
 
 inline void clock_start(uint64_t & value)
 {

--- a/src/collector/Round.cpp
+++ b/src/collector/Round.cpp
@@ -156,8 +156,7 @@ void Round::step2_1_jobs_and_history(void *arg)
 
     // This is an approximate point of time we started collecting statistics.
     // It will be used to filter history entries.
-    uint64_t start_ts = 0;
-    clock_get_real(start_ts);
+    uint64_t start_ts = clock_get_real();
 
     try {
         const Config & config = app::config();
@@ -202,8 +201,7 @@ void Round::step2_1_jobs_and_history(void *arg)
                              mongo::ReadPreference_PrimaryPreferred, mongo::BSONArray()),
                 0, 0, &jobs_fields).release());
 
-        uint64_t ts = 0;
-        clock_get_real(ts);
+        uint64_t ts = clock_get_real();
         std::vector<Job> jobs;
         size_t count = 0;
 

--- a/tests/collector/util/CMakeLists.txt
+++ b/tests/collector/util/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(util STATIC
     app.cpp
+    Clock.cpp
     )
 
-target_link_libraries(util ${COLLECTOR_LIBRARIES})
+target_link_libraries(util collector_common)

--- a/tests/collector/util/Clock.cpp
+++ b/tests/collector/util/Clock.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include <Metrics.h>
+
+#include "TestUtil.h"
+
+namespace {
+
+uint64_t test_clock = 0;
+
+} // unnamed namespace
+
+void set_test_clock(uint64_t sec, uint64_t usec)
+{
+    test_clock = sec * 1000000000ULL + usec * 1000ULL;
+}
+
+uint64_t clock_get_real()
+{
+    if (test_clock)
+        return test_clock;
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (ts.tv_sec * 1000000000ULL + ts.tv_nsec);
+}

--- a/tests/collector/util/TestUtil.h
+++ b/tests/collector/util/TestUtil.h
@@ -1,0 +1,28 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#ifndef __6b5a24ec_1b65_491c_9c5b_5840b729edb0
+#define __6b5a24ec_1b65_491c_9c5b_5840b729edb0
+
+// set_test_clock -- set value returned by clock_get_real().
+// If values are zero, value of CLOCK_REALTIME will be retrieved.
+// See clock_gettime(2).
+void set_test_clock(uint64_t sec, uint64_t usec);
+
+#endif
+


### PR DESCRIPTION
Some operations rely on system timer (e.g. we check if information about an item wasn't updated for certain amount of time and report it by status change or writing log message). It is important to have an ability to give fake values to functions getting system timer value.

It was implemented by uninlining a function `clock_get_real` and moving it into separate object file. Thus we can have different implementations for tests and for real work.

Test version `clock_get_real` will work as usual by default. In addition there is `set_test_clock` which tells `clock_get_real` to return specified value. This behavior can be reset passing zero values to `set_test_clock`.
