### PR TITLE
Describe test storage layout using JSON

### DIFF
--- a/tests/collector/util/CMakeLists.txt
+++ b/tests/collector/util/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(util STATIC
     app.cpp
     Clock.cpp
+    StorageSnapshot.cpp
+    StorageUpdater.cpp
     )
 
 target_link_libraries(util collector_common)

--- a/tests/collector/util/StorageSnapshot.cpp
+++ b/tests/collector/util/StorageSnapshot.cpp
@@ -1,0 +1,755 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "StorageSnapshot.h"
+#include "StorageUpdater.h"
+
+#include <Metrics.h>
+
+#include <stdexcept>
+
+#include <mongo/db/json.h>
+#include <rapidjson/document.h>
+
+#include <iostream>
+#include <sstream>
+
+#define DEFAULT_DC "manzhou"
+
+void StorageSnapshot::Host::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+    writer.Key("addr");
+    writer.String(addr.c_str());
+    writer.Key("name");
+    writer.String(name.c_str());
+    writer.Key("dc");
+    writer.String(dc.c_str());
+    writer.EndObject();
+}
+
+StorageSnapshot::Node::Node()
+    :
+    la(),
+    tx_bytes(),
+    rx_bytes()
+{}
+
+std::string StorageSnapshot::Node::create_key(const std::string & addr, int port, int family)
+{
+    std::ostringstream ostr;
+    ostr << addr << ':' << port << ':' << family;
+    return ostr.str();
+}
+
+void StorageSnapshot::Node::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+    writer.Key("addr");
+    writer.String(addr.c_str());
+    writer.Key("port");
+    writer.Int(port);
+    writer.Key("family");
+    writer.Int(family);
+    writer.Key("la");
+    writer.Int(la);
+    writer.Key("tx_bytes");
+    writer.Uint64(tx_bytes);
+    writer.Key("rx_bytes");
+    writer.Uint64(rx_bytes);
+    writer.EndObject();
+}
+
+void StorageSnapshot::Node::split_key(const std::string & key,
+        std::string & addr, int & port, int & family)
+{
+    size_t pos_f = key.rfind(':');
+    if (pos_f == std::string::npos)
+        throw std::invalid_argument("node key with no family");
+    family = std::stoi(key.substr(pos_f + 1));
+
+    size_t pos_p = key.rfind(':', pos_f - 1);
+    if (pos_p == std::string::npos)
+        throw std::invalid_argument("node key with no port");
+    port = std::stoi(key.substr(pos_p + 1, pos_f - pos_p - 1));
+
+    addr = key.substr(0, pos_p);
+}
+
+StorageSnapshot::Backend::Backend()
+    :
+    id(),
+    base_size(),
+    records_total(),
+    records_removed(),
+    records_removed_size(),
+    group(),
+    state(),
+    read_only(),
+    last_start(),
+    fsid()
+{}
+
+void StorageSnapshot::Backend::split_key(const std::string & key, std::string & node, int & id)
+{
+    size_t pos = key.rfind('/');
+    if (pos == std::string::npos)
+        throw std::invalid_argument("backend key with no slash");
+    id = std::stoi(key.substr(pos + 1));
+    node = key.substr(0, pos);
+}
+
+std::string StorageSnapshot::Backend::create_key(const std::string & node, uint64_t id)
+{
+    return node + '/' + std::to_string(id);
+}
+
+void StorageSnapshot::Backend::print_json(
+        rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+
+    writer.Key("node");
+    writer.String(node.c_str());
+    writer.Key("id");
+    writer.Int(id);
+
+    writer.Key("base_size");
+    writer.Int(base_size);
+    writer.Key("records_total");
+    writer.Int(records_total);
+    writer.Key("records_removed");
+    writer.Int(records_removed);
+    writer.Key("records_removed_size");
+    writer.Int(records_removed_size);
+    writer.Key("group");
+    writer.Int(group);
+
+    writer.Key("data_path");
+    writer.String(data_path.c_str());
+
+    writer.Key("state");
+    writer.Int(state);
+    writer.Key("read_only");
+    writer.Bool(read_only);
+
+    writer.Key("last_start");
+    writer.StartObject();
+        writer.Key("tv_sec");
+        writer.Uint64(last_start.tv_sec);
+        writer.Key("tv_usec");
+        writer.Uint64(last_start.tv_usec);
+    writer.EndObject();
+
+    writer.Key("fsid");
+    writer.Uint64(fsid);
+
+    writer.EndObject();
+}
+
+StorageSnapshot::FS::FS()
+    :
+    fsid(),
+    dstat(),
+    vfs()
+{}
+
+void StorageSnapshot::FS::split_key(const std::string & key, std::string & node, uint64_t & fsid)
+{
+    size_t pos = key.rfind('/');
+    if (pos == std::string::npos)
+        throw std::invalid_argument("filesystem key with no slash");
+    fsid = std::stoll(key.substr(pos + 1));
+    node = key.substr(0, pos);
+}
+
+std::string StorageSnapshot::FS::create_key(const std::string & node, uint64_t fsid)
+{
+    return node + '/' + std::to_string(fsid);
+}
+
+void StorageSnapshot::FS::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+
+    writer.Key("node");
+    writer.String(node.c_str());
+    writer.Key("fsid");
+    writer.Uint64(fsid);
+
+    writer.Key("dstat");
+    writer.StartObject();
+        writer.Key("read_ios");
+        writer.Int(dstat.read_ios);
+        writer.Key("write_ios");
+        writer.Int(dstat.write_ios);
+        writer.Key("read_ticks");
+        writer.Int(dstat.read_ticks);
+        writer.Key("write_ticks");
+        writer.Int(dstat.write_ticks);
+        writer.Key("io_ticks");
+        writer.Int(dstat.io_ticks);
+        writer.Key("read_sectors");
+        writer.Int(dstat.read_sectors);
+        writer.Key("error");
+        writer.Int(dstat.error);
+    writer.EndObject();
+
+    writer.Key("vfs");
+    writer.StartObject();
+        writer.Key("blocks");
+        writer.Int64(vfs.blocks);
+        writer.Key("bavail");
+        writer.Int64(vfs.bavail);
+        writer.Key("bsize");
+        writer.Int(vfs.bsize);
+        writer.Key("error");
+        writer.Int(vfs.error);
+    writer.EndObject();
+
+    writer.EndObject();
+}
+
+StorageSnapshot::Group::Group()
+    :
+    id(),
+    metadata()
+{}
+
+void StorageSnapshot::Group::print_json(
+        rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+
+    writer.Key("id");
+    writer.Int(id);
+
+    writer.Key("metadata");
+    writer.StartObject();
+        if (metadata.version) {
+            writer.Key("version");
+            writer.Int(metadata.version);
+        }
+        if (metadata.frozen) {
+            writer.Key("frozen");
+            writer.Bool(metadata.frozen);
+        }
+        if (!metadata.couple.empty()) {
+            writer.Key("couple");
+            writer.StartArray();
+                for (int g : metadata.couple)
+                    writer.Int(g);
+            writer.EndArray();
+        }
+        if (!metadata.ns.empty()) {
+            writer.Key("namespace");
+            writer.String(metadata.ns.c_str());
+        }
+        if (!metadata.type.empty()) {
+            writer.Key("type");
+            writer.String(metadata.type.c_str());
+        }
+        if (metadata.service.migrating || !metadata.service.job_id.empty()) {
+            writer.Key("service");
+            writer.StartObject();
+                if (metadata.service.migrating) {
+                    writer.Key("migrating");
+                    writer.Bool(metadata.service.migrating);
+                    writer.Key("job_id");
+                    writer.String(metadata.service.job_id.c_str());
+                }
+            writer.EndObject();
+        }
+    writer.EndObject();
+
+    writer.Key("backends");
+    writer.StartArray();
+        for (const std::string & b : backends)
+            writer.String(b.c_str());
+    writer.EndArray();
+
+    writer.EndObject();
+}
+
+StorageSnapshot::StorageSnapshot()
+    :
+    m_default_ts(0),
+    m_history_ts(0)
+{}
+
+StorageSnapshot::StorageSnapshot(const char *json)
+    :
+    m_history_ts(0)
+{
+    update(json);
+    complete();
+}
+
+void StorageSnapshot::update(const char *json)
+{
+    using namespace rapidjson;
+
+    m_default_ts = clock_get_real();
+
+    Document doc;
+    doc.Parse(json);
+
+    if (doc.HasParseError())
+        throw std::invalid_argument("Wrong JSON");
+
+    if (doc.HasMember("timestamp")) {
+        Value & t = doc["timestamp"];
+        if (!t.IsObject())
+            throw std::invalid_argument("default timestamp is not an object");
+
+        m_default_ts = t["tv_sec"].GetInt64() * 1000000000ULL + t["tv_usec"].GetInt64() * 1000ULL;
+    }
+
+    if (doc.HasMember("hosts")) {
+        Value & hosts = doc["hosts"];
+        if (!hosts.IsObject())
+            throw std::invalid_argument("hosts is not an object");
+
+        for (Value::MemberIterator it = hosts.MemberBegin(); it != hosts.MemberEnd(); ++it) {
+            std::string addr = it->name.GetString();
+            const Value & h = it->value;
+
+            Host & host = m_hosts[addr];
+            host.addr = addr;
+
+            if (h.HasMember("name"))
+                host.name = h["name"].GetString();
+            if (h.HasMember("dc"))
+                host.dc = h["dc"].GetString();
+        }
+    }
+
+    if (doc.HasMember("nodes")) {
+        Value & nodes = doc["nodes"];
+        if (!nodes.IsObject())
+            throw std::invalid_argument("nodes is not an object");
+
+        for (Value::MemberIterator it = nodes.MemberBegin(); it != nodes.MemberEnd(); ++it) {
+            std::string key = it->name.GetString();
+            const Value & n = it->value;
+
+            if (n.IsNull()) {
+                m_nodes.erase(key);
+                continue;
+            }
+
+            Node & node = m_nodes[key];
+
+            Node::split_key(key, node.addr, node.port, node.family);
+
+            if (n.HasMember("la"))
+                node.la = n["la"].GetInt();
+            if (n.HasMember("tx_bytes"))
+                node.tx_bytes = n["tx_bytes"].GetUint64();
+            if (n.HasMember("rx_bytes"))
+                node.rx_bytes = n["rx_bytes"].GetUint64();
+        }
+    }
+
+    if (doc.HasMember("backends")) {
+        Value & backends = doc["backends"];
+
+        if (!backends.IsObject())
+            throw std::invalid_argument("backends is not an object");
+
+        for (Value::MemberIterator it = backends.MemberBegin();
+                it != backends.MemberEnd(); ++it) {
+            std::string key = it->name.GetString();
+            const Value & b = it->value;
+
+            if (b.IsNull()) {
+                m_backends.erase(key);
+                continue;
+            }
+
+            Backend & backend = m_backends[key];
+
+            Backend::split_key(key, backend.node, backend.id);
+
+            if (b.HasMember("base_size"))
+                backend.base_size = b["base_size"].GetInt();
+            if (b.HasMember("records_total"))
+                backend.records_total = b["records_total"].GetInt();
+            if (b.HasMember("records_removed"))
+                backend.records_removed = b["records_removed"].GetInt();
+            if (b.HasMember("records_removed_size"))
+                backend.records_removed_size = b["records_removed_size"].GetInt();
+
+            if (b.HasMember("group"))
+                backend.group = b["group"].GetInt();
+
+            if (b.HasMember("data_path"))
+                backend.data_path = b["data_path"].GetString();
+
+            if (b.HasMember("state"))
+                backend.state = b["state"].GetInt();
+            if (b.HasMember("read_only"))
+                backend.read_only = b["read_only"].GetBool();
+
+            if (b.HasMember("last_start")) {
+                const Value & ls = b["last_start"];
+                if (ls.HasMember("tv_sec"))
+                    backend.last_start.tv_sec = ls["tv_sec"].GetInt64();
+                if (ls.HasMember("tv_usec"))
+                    backend.last_start.tv_usec = ls["tv_usec"].GetInt64();
+            }
+
+            if (b.HasMember("fsid"))
+                backend.fsid = b["fsid"].GetInt64();
+        }
+    }
+
+    if (doc.HasMember("filesystems")) {
+        Value & filesystems = doc["filesystems"];
+
+        if (!filesystems.IsObject())
+            throw std::invalid_argument("filesystems is not an object");
+
+        for (Value::MemberIterator it = filesystems.MemberBegin();
+                it != filesystems.MemberEnd(); ++it) {
+            std::string key = it->name.GetString();
+            const Value & f = it->value;
+
+            if (f.IsNull()) {
+                m_filesystems.erase(key);
+                continue;
+            }
+
+            FS & fs = m_filesystems[key];
+
+            FS::split_key(key, fs.node, fs.fsid);
+
+            if (f.HasMember("dstat")) {
+                const Value & d = f["dstat"];
+                if (d.HasMember("read_ios"))
+                    fs.dstat.read_ios = d["read_ios"].GetInt();
+                if (d.HasMember("write_ios"))
+                    fs.dstat.write_ios = d["write_ios"].GetInt();
+                if (d.HasMember("read_ticks"))
+                    fs.dstat.read_ticks = d["read_ticks"].GetInt();
+                if (d.HasMember("write_ticks"))
+                    fs.dstat.write_ticks = d["write_ticks"].GetInt();
+                if (d.HasMember("io_ticks"))
+                    fs.dstat.io_ticks = d["io_ticks"].GetInt();
+                if (d.HasMember("read_sectors"))
+                    fs.dstat.read_sectors = d["read_sectors"].GetInt();
+                if (d.HasMember("error"))
+                    fs.dstat.error = d["error"].GetInt();
+            }
+
+            if (f.HasMember("vfs")) {
+                const Value & v = f["vfs"];
+                if (v.HasMember("blocks"))
+                    fs.vfs.blocks = v["blocks"].GetInt64();
+                if (v.HasMember("bavail"))
+                    fs.vfs.bavail = v["bavail"].GetInt64();
+                if (v.HasMember("bsize"))
+                    fs.vfs.bsize = v["bsize"].GetInt();
+                if (v.HasMember("error"))
+                    fs.vfs.error = v["error"].GetInt();
+            }
+        }
+    }
+
+    if (doc.HasMember("groups")) {
+        Value & groups = doc["groups"];
+
+        if (!groups.IsObject())
+            throw std::invalid_argument("groups is not an object");
+
+        for (Value::MemberIterator it = groups.MemberBegin();
+                it != groups.MemberEnd(); ++it) {
+            std::string id_str = it->name.GetString();
+            const Value & g = it->value;
+
+            int id = std::stoi(id_str);
+
+            if (g.IsNull()) {
+                m_groups.erase(id);
+                continue;
+            }
+
+            Group & group = m_groups[id];
+            group.id = id;
+
+            if (g.HasMember("metadata")) {
+                const Value & m = g["metadata"];
+                if (m.HasMember("version"))
+                    group.metadata.version = m["version"].GetInt();
+                if (m.HasMember("frozen"))
+                    group.metadata.frozen = m["frozen"].GetBool();
+                if (m.HasMember("couple")) {
+                    const Value & c = m["couple"];
+                    if (!c.IsArray())
+                        throw std::invalid_argument("couple is not an array");
+                    for (SizeType i = 0; i < c.Size(); ++i)
+                        group.metadata.couple.push_back(c[i].GetInt());
+                }
+                if (m.HasMember("namespace"))
+                    group.metadata.ns = m["namespace"].GetString();
+                if (m.HasMember("type"))
+                    group.metadata.type = m["type"].GetString();
+                if (m.HasMember("service")) {
+                    const Value & s = m["service"];
+                    if (s.HasMember("migrating"))
+                        group.metadata.service.migrating = s["migrating"].GetBool();
+                    if (s.HasMember("job_id"))
+                        group.metadata.service.job_id = s["job_id"].GetString();
+                }
+            }
+
+            if (g.HasMember("backends")) {
+                const Value & b = g["backends"];
+                if (!b.IsArray())
+                    throw std::invalid_argument("group backends is not an array");
+
+                group.backends.clear();
+                for (SizeType i = 0; i < b.Size(); ++i)
+                    group.backends.push_back(b[i].GetString());
+            }
+        }
+    }
+
+    if (doc.HasMember("history")) {
+        const Value & history = doc["history"];
+
+        if (!history.IsObject())
+            throw std::invalid_argument("history is not an object");
+
+        if (history.HasMember("timestamp"))
+            m_history_ts = history["timestamp"].GetInt64();
+        else
+            m_history_ts = m_default_ts;
+
+        if (history.HasMember("entries")) {
+            const Value & s = history["entries"];
+            if (!s.IsArray())
+                throw std::invalid_argument("history/entries is not an array");
+
+            for (Value::ConstValueIterator it = s.Begin(); it != s.End(); ++it) {
+                const Value & e = *it;
+
+                StringBuffer buf;
+                Writer<StringBuffer> writer(buf);
+                e.Accept(writer);
+
+                mongo::BSONObj bson = mongo::fromjson(buf.GetString());
+                GroupHistoryEntry entry(bson);
+
+                m_history.emplace_back(std::move(entry));
+            }
+        }
+    }
+}
+
+void StorageSnapshot::complete()
+{
+    complete_nodes();
+    complete_filesystems();
+    complete_backends();
+    complete_groups();
+}
+
+void StorageSnapshot::create_host(const std::string & addr)
+{
+    Host host;
+    host.addr = addr;
+    do {
+        static int counter = 0;
+        host.name = "node" + std::to_string(++counter) + ".example.com";
+    } while (m_hosts.find(host.name) != m_hosts.end());
+    host.dc = DEFAULT_DC;
+    m_hosts[host.addr] = host;
+}
+
+void StorageSnapshot::complete_nodes()
+{
+    // Create hosts if needed.
+    for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it) {
+        const Node & node = it->second;
+        if (m_hosts.find(node.addr) == m_hosts.end())
+            create_host(node.addr);
+    }
+}
+
+void StorageSnapshot::create_node(const std::string & key)
+{
+    Node & node = m_nodes[key];
+    Node::split_key(key, node.addr, node.port, node.family);
+
+    if (m_hosts.find(node.addr) == m_hosts.end())
+        create_host(node.addr);
+}
+
+void StorageSnapshot::complete_filesystems()
+{
+    // Create nodes if needed.
+    for (auto it = m_filesystems.begin(); it != m_filesystems.end(); ++it) {
+        const FS & fs = it->second;
+        if (m_nodes.find(fs.node) == m_nodes.end())
+            create_node(fs.node);
+    }
+}
+
+uint64_t StorageSnapshot::create_filesystem(const std::string & node, uint64_t fsid)
+{
+    std::string key;
+    if (!fsid) {
+        static uint64_t fsid_gen = 1224124459;
+        do {
+            fsid = fsid_gen++;
+            key = FS::create_key(node, fsid);
+        } while (m_filesystems.find(key) != m_filesystems.end());
+    } else {
+        key = FS::create_key(node, fsid);
+    }
+
+    FS & fs = m_filesystems[key];
+    fs.node = node;
+    fs.fsid = fsid;
+
+    fs.vfs.blocks = 0x40000000; // 4TB
+    fs.vfs.bavail = fs.vfs.blocks - 11681;
+    fs.vfs.bsize = 4096;
+
+    if (m_nodes.find(node) == m_nodes.end())
+        create_node(node);
+
+    return fsid;
+}
+
+void StorageSnapshot::complete_backends()
+{
+    // Create filesystems if needed.
+    for (auto it = m_backends.begin(); it != m_backends.end(); ++it) {
+        const Backend & backend = it->second;
+        if (m_filesystems.find(FS::create_key(backend.node, backend.fsid)) ==
+                m_filesystems.end())
+            create_filesystem(backend.node, backend.fsid);
+    }
+}
+
+void StorageSnapshot::create_backend(const std::string & key, int group)
+{
+    std::string node;
+    int id = 0;
+    Backend::split_key(key, node, id);
+
+    Backend & backend = m_backends[key];
+    backend.node = node;
+    backend.id = id;
+
+    backend.group = group;
+    backend.data_path = "/path/to/data/1/1";
+
+    backend.state = 1;
+
+    backend.fsid = create_filesystem(node, 0);
+}
+
+void StorageSnapshot::complete_groups()
+{
+    // Create backends if needed.
+    for (auto it = m_groups.begin(); it != m_groups.end(); ++it) {
+        const Group & group = it->second;
+        for (const std::string & bkey : group.backends) {
+            if (m_backends.find(bkey) == m_backends.end())
+                create_backend(bkey, group.id);
+        }
+    }
+}
+
+void StorageSnapshot::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
+{
+    writer.StartObject();
+        writer.Key("default_ts");
+        writer.Uint64(m_default_ts);
+
+        writer.Key("hosts");
+        writer.StartObject();
+        for (auto it = m_hosts.begin(); it != m_hosts.end(); ++it) {
+            const Host & host = it->second;
+            writer.Key(it->first.c_str());
+            host.print_json(writer);
+        }
+        writer.EndObject();
+
+        writer.Key("nodes");
+        writer.StartObject();
+        for (auto it = m_nodes.begin(); it != m_nodes.end(); ++it) {
+            const Node & node = it->second;
+            writer.Key(it->first.c_str());
+            node.print_json(writer);
+        }
+        writer.EndObject();
+
+        writer.Key("backends");
+        writer.StartObject();
+        for (auto it = m_backends.begin(); it != m_backends.end(); ++it) {
+            const Backend & backend = it->second;
+            writer.Key(it->first.c_str());
+            backend.print_json(writer);
+        }
+        writer.EndObject();
+
+        writer.Key("filesystems");
+        writer.StartObject();
+        for (auto it = m_filesystems.begin(); it != m_filesystems.end(); ++it) {
+            const FS & fs = it->second;
+            writer.Key(it->first.c_str());
+            fs.print_json(writer);
+        }
+        writer.EndObject();
+
+        writer.Key("groups");
+        writer.StartObject();
+        for (auto it = m_groups.begin(); it != m_groups.end(); ++it) {
+            const Group & group = it->second;
+            writer.Key(std::to_string(it->first).c_str());
+            group.print_json(writer);
+        }
+        writer.EndObject();
+
+        writer.Key("history");
+        writer.StartObject();
+            writer.Key("timestamp");
+            writer.Uint64(m_history_ts);
+            writer.Key("entries");
+            writer.StartArray();
+            // TODO: uncomment after GroupHistoryEntry::print_json() is ready
+            // for (const auto & entry : m_history)
+            //    entry.print_json(writer);
+            writer.EndArray();
+        writer.EndObject();
+    writer.EndObject();
+}
+
+std::ostream & operator << (std::ostream & ostr, const StorageSnapshot & snapshot)
+{
+    rapidjson::StringBuffer buf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+
+    snapshot.print_json(writer);
+    ostr << buf.GetString();
+    return ostr;
+}

--- a/tests/collector/util/StorageSnapshot.h
+++ b/tests/collector/util/StorageSnapshot.h
@@ -1,0 +1,391 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#ifndef __1d79a13a_c6da_41c1_ac83_40048c030738
+#define __1d79a13a_c6da_41c1_ac83_40048c030738
+
+#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include <rapidjson/writer.h>
+
+#include <GroupHistoryEntry.h>
+
+// The idea is to have an ability to describe test setup using minimalistic
+// JSON document containing only key information about items.
+//
+// For instance, suppose you want to test if given two groups having enabled
+// backends and metadata a new couple is created and has correct status
+// calculated.
+//
+// In this case you don't care about particular values (e.g. filesystem block
+// size) and don't want to provide full information about the cluster. All you
+// need is basic information. StorageSnapshot and StorageUpdater allow you to
+// build Storage object with Nodes, Backends, and so on using following simple
+// schema:
+//
+// {
+//     "groups": {
+//         "1": {
+//             "metadata": {
+//                 "version": 2,
+//                 "couple": [ 1, 2 ],
+//                 "namespace": "default"
+//             },
+//             "backends": [
+//                 "2001:db8:0:1111::11:1025:10/101"
+//             ]
+//         },
+//         "2": {
+//             "metadata": {
+//                 "version": 2,
+//                 "couple": [ 1, 2 ],
+//                 "namespace": "default"
+//             },
+//             "backends": [
+//                 "2001:db8:0:1122::14:1025:10/907"
+//             ]
+//         }
+//     }
+// }
+//
+// Although in real life this layout could be built after receiving a lot of
+// information from different sources (elliptics nodes, monitor stats, group
+// metadata), some set of default values is enough for a large number of tests.
+// Of course, you can specify more details, for example, adding description
+// for some backends or nodes.
+//
+// Note that it is not required to define intermediate objects, for example,
+// if you want to tell explicitly in which data centers backends reside, you
+// will only need to fill "hosts" section in the document.
+//
+// After processing this document SorageSnapshot will end up building all
+// implied objects with default values. All items are represented by
+// StorageSnapshot's own data structures, there are no dependencies to
+// Storage objects.
+//
+// When complete storage snapshot is built, you may use StorageUpdater to
+// build Storage structure from it. See StorageUpdater class description.
+//
+// Here is an example document with all currently supported values set.
+//
+// {
+//     "timestamp": {
+//         "tv_sec": 1450875367,
+//         "tv_usec": 734537
+//     },
+//     "hosts": {
+//         "2001:db8:0:1111::11": {
+//             "name": "node01.example.net",
+//             "dc": "manzhou"
+//         },
+//         "2001:db8:0:1122::14": {
+//             "name": "node11.example.net",
+//             "dc": "vaal"
+//         }
+//     },
+//     "nodes": {
+//         "2001:db8:0:1111::11:1025:10": {
+//             "la": 31,
+//             "tx_bytes": 1778628811,
+//             "rx_bytes": 1219421323
+//         }
+//     },
+//     "backends": {
+//         "2001:db8:0:1111::11:1025:10/101": {
+//             "base_size": 232524191,
+//             "records_total": 30029,
+//             "records_removed": 22171,
+//             "records_removed_size": 138139,
+//             "group": 1,
+//             "data_path": "/path/to/data/1/1",
+//             "state": 1,
+//             "read_only": 0,
+//             "last_start": {
+//                 "tv_sec": 1450875311,
+//                 "tv_usec": 16103
+//             },
+//             "fsid": 1164930671
+//         }
+//     },
+//     "filesystems": {
+//         "2001:db8:0:1111::11:1025:10/1164930671": {
+//             "dstat": {
+//                 "read_ios": 204140011,
+//                 "write_ios": 1518120647,
+//                 "read_ticks": 19469599,
+//                 "write_ticks": 38566807,
+//                 "io_ticks": 412932577,
+//                 "read_sectors": 116130083,
+//                 "error": 0
+//             },
+//             "vfs": {
+//                 "blocks": 255075559,
+//                 "bavail": 255073001,
+//                 "bsize": 4096,
+//                 "error": 0
+//             }
+//         }
+//     },
+//     "groups": {
+//         "1": {
+//             "metadata": {
+//                 "version": 2,
+//                 "couple": [ 1, 2 ],
+//                 "namespace": "default",
+//                 "frozen": true,
+//                 "type": "cache",
+//                 "service": {
+//                     "migrating": true,
+//                     "job_id": "abcdef"
+//                 }
+//             },
+//             "backends": [
+//                 "2001:db8:0:1111::11:1025:10/101"
+//             ]
+//         }
+//     },
+//     "history": {
+//         "timestamp": 1450875247000123000,
+//         "entries": [
+//             {
+//                 "group_id": 3,
+//                 "nodes": [
+//                     {
+//                         "timestamp": 1449841663,
+//                         "type": "job",
+//                         "set": [
+//                             {
+//                                 "path": "/path/to/storage/3/3",
+//                                 "backend_id": 3,
+//                                 "hostname": "node2.example.com",
+//                                 "port": 1025,
+//                                 "family": 10
+//                             }
+//                         ]
+//                     }
+//                 ]
+//             }
+//         ]
+//     }
+// }
+//
+// StorageSnapshot is initialized with JSON passed to constructor or to update()
+// method. Method complete() is used to generate all implied objects.
+//
+// Subsequent calls to update() will modify current structure. You may also want
+// to delete an item, i.e. information about it will not reach storage on the
+// next call to StorageUpdater. To do this, put null value instead of object
+// description in correspondent section:
+//
+// {
+//     "backends": {
+//         "2001:db8:0:1111::11:1025:10/101": null
+//     }
+// }
+
+class StorageSnapshot
+{
+public:
+    struct Host
+    {
+        std::string addr;
+        std::string name;
+        std::string dc;
+
+        void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+    };
+
+    struct Node
+    {
+        Node();
+
+        std::string addr;
+        int port;
+        int family;
+
+        int la;
+        uint64_t tx_bytes;
+        uint64_t rx_bytes;
+
+        static void split_key(const std::string & key, std::string & addr, int & port, int & family);
+
+        static std::string create_key(const std::string & addr, int port, int family);
+
+        void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+    };
+
+    struct Backend
+    {
+        Backend();
+
+        std::string node;
+
+        int id;
+
+        int base_size;
+        int records_total;
+        int records_removed;
+        int records_removed_size;
+
+        int group;
+
+        std::string data_path;
+
+        int state;
+        bool read_only;
+
+        struct {
+            uint64_t tv_sec;
+            uint64_t tv_usec;
+        } last_start;
+
+        uint64_t fsid;
+
+        static void split_key(const std::string & key, std::string & node, int & id);
+
+        static std::string create_key(const std::string & node, uint64_t id);
+
+        void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+    };
+
+    struct FS
+    {
+        FS();
+
+        std::string node;
+        uint64_t fsid;
+
+        struct {
+            int read_ios;
+            int write_ios;
+            int read_ticks;
+            int write_ticks;
+            int io_ticks;
+            int read_sectors;
+            int error;
+        } dstat;
+
+        struct {
+            int64_t blocks;
+            int64_t bavail;
+            int bsize;
+            int error;
+        } vfs;
+
+        static void split_key(const std::string & key, std::string & node, uint64_t & fsid);
+
+        static std::string create_key(const std::string & node, uint64_t fsid);
+
+        void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+    };
+
+    struct Group
+    {
+        Group();
+
+        int id;
+        struct {
+            int version;
+            bool frozen;
+            std::vector<int> couple;
+            std::string ns;
+            std::string type;
+            struct {
+                bool migrating;
+                std::string job_id;
+            } service;
+        } metadata;
+        std::vector<std::string> backends;
+
+        void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+    };
+
+public:
+    StorageSnapshot();
+    StorageSnapshot(const char *json);
+
+    // Update current schema.
+    void update(const char *json);
+
+    // Generate all implied objects (see the description above).
+    void complete();
+
+    const std::map<std::string, Host> & get_hosts() const
+    { return m_hosts; }
+
+    const std::map<std::string, Node> & get_nodes() const
+    { return m_nodes; }
+
+    const std::map<std::string, Backend> & get_backends() const
+    { return m_backends; }
+
+    const std::map<std::string, FS> & get_filesystems() const
+    { return m_filesystems; }
+
+    const std::map<int, Group> & get_groups() const
+    { return m_groups; }
+
+    std::vector<GroupHistoryEntry> pick_group_history()
+    { return std::move(m_history); }
+
+    uint64_t get_default_ts() const
+    { return m_default_ts; }
+
+    uint64_t get_history_ts() const
+    { return m_history_ts; }
+
+    // Generate JSON schema. Currently this method is used for debugging
+    // purposes.
+    void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const;
+
+private:
+    void create_host(const std::string & addr);
+    void complete_nodes();
+    void create_node(const std::string & key);
+    void complete_filesystems();
+    uint64_t create_filesystem(const std::string & node, uint64_t fsid);
+    void complete_backends();
+    void create_backend(const std::string & key, int group);
+    void complete_groups();
+
+private:
+    // Default timestamp
+    uint64_t m_default_ts;
+    // Address -> Host
+    std::map<std::string, Host> m_hosts;
+    // address:port:family -> Node
+    std::map<std::string, Node> m_nodes;
+    // address:port:family/id -> Backend
+    std::map<std::string, Backend> m_backends;
+    // address:port:family/fsid -> FS
+    std::map<std::string, FS> m_filesystems;
+    // Group id -> Group
+    std::map<int, Group> m_groups;
+    // Group history
+    std::vector<GroupHistoryEntry> m_history;
+    // History timestamp
+    uint64_t m_history_ts;
+};
+
+std::ostream & operator << (std::ostream & ostr, const StorageSnapshot & snapshot);
+
+#endif
+

--- a/tests/collector/util/StorageUpdater.cpp
+++ b/tests/collector/util/StorageUpdater.cpp
@@ -1,0 +1,365 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#include "StorageUpdater.h"
+
+#include <Group.h>
+#include <Host.h>
+#include <Storage.h>
+
+#include <msgpack.hpp>
+
+StorageUpdater::StorageUpdater(Storage & storage, StorageSnapshot & snapshot)
+    :
+    m_storage(storage),
+    m_snapshot(snapshot)
+{}
+
+void StorageUpdater::update_nodes()
+{
+    // Update hosts.
+    {
+        const auto & hosts = m_snapshot.get_hosts();
+        for (auto it = hosts.begin(); it != hosts.end(); ++it) {
+            const auto & sn_host = it->second;
+            Host & st_host = m_storage.get_host(it->first);
+            st_host.set_name(sn_host.name);
+            st_host.set_dc(sn_host.dc);
+        }
+    }
+
+    // Update nodes.
+    const auto & nodes = m_snapshot.get_nodes();
+    for (auto it = nodes.begin(); it != nodes.end(); ++it) {
+        const auto & sn_node = it->second;
+        if (!m_storage.has_node(sn_node.addr.c_str(), sn_node.port, sn_node.family)) {
+            const Host & st_host = m_storage.get_host(sn_node.addr);
+            m_storage.add_node(st_host, sn_node.port, sn_node.family);
+        }
+    }
+}
+
+void StorageUpdater::update_monitor_stats()
+{
+    auto & sn_backends = m_snapshot.get_backends();
+    auto & sn_nodes = m_snapshot.get_nodes();
+    auto & sn_filesystems = m_snapshot.get_filesystems();
+
+    for (auto it = sn_nodes.begin(); it != sn_nodes.end(); ++it) {
+        const std::string & node_key = it->first;
+        const auto & sn_node = it->second;
+
+        rapidjson::StringBuffer buf;
+        rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+
+        // Start the entire document.
+        writer.StartObject();
+
+        // Add procfs and timestamp.
+        add_node(writer, sn_node);
+
+        // Add backends living on current node.
+        writer.Key("backends");
+        writer.StartObject();
+        for (auto bit = sn_backends.begin(); bit != sn_backends.end(); ++bit) {
+            const auto & sn_backend = bit->second;
+            if (sn_backend.node == node_key) {
+                writer.Key(std::to_string(sn_backend.id).c_str());
+                add_backend(writer, sn_backend, sn_filesystems.find(
+                        StorageSnapshot::FS::create_key(node_key, sn_backend.fsid))->second);
+            }
+        }
+        writer.EndObject();
+
+        // End of the document.
+        writer.EndObject();
+
+        // This is full monitor stats JSON for this node.
+        std::string json_str = buf.GetString();
+
+        // Apply JSON to node.
+        auto & st_nodes = m_storage.get_nodes();
+        Node & st_node = st_nodes.find(node_key)->second;
+        st_node.add_download_data(json_str.c_str(), json_str.size());
+        Node::parse_stats(&st_node);
+
+    }
+
+    m_storage.save_group_history(std::move(m_snapshot.pick_group_history()),
+        m_snapshot.get_history_ts());
+
+    // Update group structure, etc.
+    m_storage.process_node_backends();
+}
+
+void StorageUpdater::update_metadata()
+{
+    // For each group generate msgpack:ed group metadata and pass buffer to the group.
+
+    auto & st_groups = m_storage.get_groups();
+    auto & sn_groups = m_snapshot.get_groups();
+
+    for (auto it = st_groups.begin(); it != st_groups.end(); ++it) {
+        int id = it->first;
+        Group & st_group = it->second;
+
+        // It is not necessary that the group is defined in snapshot.
+        // In real life it would be "metadata download failed".
+        auto jt = sn_groups.find(id);
+        if (jt != sn_groups.end())
+            add_metadata(st_group, jt->second);
+    }
+}
+
+void StorageUpdater::update()
+{
+    m_storage.update();
+}
+
+void StorageUpdater::update_all()
+{
+    update_nodes();
+    update_monitor_stats();
+    update_metadata();
+    update();
+}
+
+void StorageUpdater::add_node(rapidjson::Writer<rapidjson::StringBuffer> & writer,
+        const StorageSnapshot::Node & node)
+{
+    // Add procfs and timestamp to monitor_stats.
+
+    uint64_t sec = m_snapshot.get_default_ts() / 1000000000ULL;
+    uint64_t usec = (m_snapshot.get_default_ts() / 1000ULL) % 1000000ULL;
+
+    writer.Key("timestamp");
+    writer.StartObject();
+        writer.Key("tv_sec");
+        writer.Uint64(sec);
+        writer.Key("tv_usec");
+        writer.Uint64(usec);
+    writer.EndObject();
+
+    writer.Key("procfs");
+    writer.StartObject();
+        writer.Key("vm");
+        writer.StartObject();
+            writer.Key("la");
+            writer.StartArray();
+                writer.Int(node.la);
+                writer.Int(node.la);
+                writer.Int(node.la);
+            writer.EndArray();
+        writer.EndObject();
+
+        writer.Key("net");
+        writer.StartObject();
+            writer.Key("net_interfaces");
+            writer.StartObject();
+                writer.Key("eth0");
+                writer.StartObject();
+                    writer.Key("receive");
+                    writer.StartObject();
+                        writer.Key("bytes");
+                        writer.Uint64(node.rx_bytes);
+                    writer.EndObject();
+                    writer.Key("transmit");
+                    writer.StartObject();
+                        writer.Key("bytes");
+                        writer.Uint64(node.tx_bytes);
+                    writer.EndObject();
+                writer.EndObject();
+            writer.EndObject();
+        writer.EndObject();
+    writer.EndObject();
+}
+
+void StorageUpdater::add_backend(rapidjson::Writer<rapidjson::StringBuffer> & writer,
+        const StorageSnapshot::Backend & backend, const StorageSnapshot::FS & fs)
+{
+    writer.StartObject();
+
+    writer.Key("backend_id");
+    writer.Int(backend.id);
+
+    writer.Key("status");
+    writer.StartObject();
+        writer.Key("state");
+        writer.Int(backend.state);
+        writer.Key("read_only");
+        writer.Bool(backend.read_only);
+        writer.Key("last_start");
+        writer.StartObject();
+            writer.Key("tv_sec");
+            writer.Uint64(backend.last_start.tv_sec);
+            writer.Key("tv_usec");
+            writer.Uint64(backend.last_start.tv_usec);
+        writer.EndObject();
+    writer.EndObject();
+
+    writer.Key("backend");
+    writer.StartObject();
+        writer.Key("summary_stats");
+        writer.StartObject();
+            writer.Key("base_size");
+            writer.Int(backend.base_size);
+            writer.Key("records_total");
+            writer.Int(backend.records_total);
+            writer.Key("records_removed");
+            writer.Int(backend.records_removed);
+            writer.Key("records_removed_size");
+            writer.Int(backend.records_removed_size);
+        writer.EndObject();
+
+        writer.Key("config");
+        writer.StartObject();
+            writer.Key("group");
+            writer.Int(backend.group);
+            writer.Key("data");
+            writer.String(backend.data_path.c_str());
+        writer.EndObject();
+
+        writer.Key("vfs");
+        writer.StartObject();
+            writer.Key("fsid");
+            writer.Int64(fs.fsid);
+            writer.Key("blocks");
+            writer.Int64(fs.vfs.blocks);
+            writer.Key("bavail");
+            writer.Int64(fs.vfs.bavail);
+            writer.Key("bsize");
+            writer.Int(fs.vfs.bsize);
+            if (fs.vfs.error) {
+                writer.Key("error");
+                writer.Int(fs.vfs.error);
+            }
+        writer.EndObject();
+
+        writer.Key("dstat");
+        writer.StartObject();
+            writer.Key("read_ios");
+            writer.Int(fs.dstat.read_ios);
+            writer.Key("write_ios");
+            writer.Int(fs.dstat.write_ios);
+            writer.Key("read_ticks");
+            writer.Int(fs.dstat.read_ticks);
+            writer.Key("write_ticks");
+            writer.Int(fs.dstat.write_ticks);
+            writer.Key("io_ticks");
+            writer.Int(fs.dstat.io_ticks);
+            writer.Key("read_sectors");
+            writer.Int(fs.dstat.read_sectors);
+            if (fs.dstat.error) {
+                writer.Key("error");
+                writer.Int(fs.dstat.error);
+            }
+        writer.EndObject();
+    writer.EndObject();
+
+    writer.EndObject();
+}
+
+void StorageUpdater::add_metadata(Group & st_group, const StorageSnapshot::Group & sn_group)
+{
+    // Both metadata of version 1 and 2 are supported.
+
+    switch (sn_group.metadata.version)
+    {
+    case 1:
+        add_metadata_V1(st_group, sn_group);
+        break;
+    case 2:
+        add_metadata_V2(st_group, sn_group);
+        break;
+    default:
+        break;
+    }
+}
+
+void StorageUpdater::add_metadata_V1(Group & st_group, const StorageSnapshot::Group & sn_group)
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> packer(&buffer);
+    packer.pack_array(sn_group.metadata.couple.size());
+    for (int id : sn_group.metadata.couple)
+        packer.pack(id);
+
+    st_group.save_metadata(buffer.data(), buffer.size(), ::time(nullptr)*1000000000ULL);
+}
+
+void StorageUpdater::add_metadata_V2(Group & st_group, const StorageSnapshot::Group & sn_group)
+{
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> packer(&buffer);
+
+    int map_size = 1;
+    if (sn_group.metadata.frozen)
+        ++map_size;
+    if (!sn_group.metadata.couple.empty())
+        ++map_size;
+    if (!sn_group.metadata.ns.empty())
+        ++map_size;
+    if (!sn_group.metadata.type.empty())
+        ++map_size;
+    if (sn_group.metadata.service.migrating ||
+            !sn_group.metadata.service.job_id.empty())
+        ++map_size;
+
+    packer.pack_map(map_size);
+
+    packer.pack(std::string("version"));
+    packer.pack(2);
+
+    if (sn_group.metadata.frozen) {
+        packer.pack(std::string("frozen"));
+        packer.pack(true);
+    }
+
+    if (!sn_group.metadata.couple.empty()) {
+        packer.pack(std::string("couple"));
+        packer.pack_array(sn_group.metadata.couple.size());
+        for (int id : sn_group.metadata.couple)
+            packer.pack(id);
+    }
+
+    if (!sn_group.metadata.ns.empty()) {
+        packer.pack(std::string("namespace"));
+        packer.pack(sn_group.metadata.ns);
+    }
+
+    if (!sn_group.metadata.type.empty()) {
+        packer.pack(std::string("type"));
+        packer.pack(sn_group.metadata.type);
+    }
+
+    if (sn_group.metadata.service.migrating ||
+            !sn_group.metadata.service.job_id.empty()) {
+        packer.pack(std::string("service"));
+        packer.pack_map(2);
+        if (sn_group.metadata.service.migrating) {
+            packer.pack(std::string("status"));
+            packer.pack(std::string("MIGRATING"));
+        }
+        if (!sn_group.metadata.service.job_id.empty()) {
+            packer.pack(std::string(std::string("job_id")));
+            packer.pack(sn_group.metadata.service.job_id);
+        }
+    }
+
+    st_group.save_metadata(buffer.data(), buffer.size(), ::time(nullptr)*1000000000ULL);
+}

--- a/tests/collector/util/StorageUpdater.h
+++ b/tests/collector/util/StorageUpdater.h
@@ -1,0 +1,74 @@
+/*
+   Copyright (c) YANDEX LLC, 2015. All rights reserved.
+   This file is part of Mastermind.
+
+   Mastermind is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 3.0 of the License, or (at your option) any later version.
+
+   Mastermind is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with Mastermind.
+*/
+
+#ifndef __94562dbe_210a_4cc2_83bb_389b3549224b
+#define __94562dbe_210a_4cc2_83bb_389b3549224b
+
+#include "StorageSnapshot.h"
+
+#include <rapidjson/document.h>
+
+class Group;
+class Storage;
+
+// StorageUpdater is used to fully construct Storage object from a layout
+// represented by StorageSnapshot. Following steps will be performed:
+// 1) Hosts will be passed to storage with call to get_host() (it is
+//    normally done by Discovery).
+// 2) Nodes will be added (Discovery does it).
+// 3) All nodes will receive JSON in a format of monitor stats.
+// 4) All groups will receive msgpack'ed metadata (Group::save_metadata).
+// 5) Storage methods will be called in the same way as Round does it.
+//
+// So the result is the same as if all data would be received in the usual way.
+
+class StorageUpdater
+{
+public:
+    StorageUpdater(Storage & storage, StorageSnapshot & snapshot);
+
+    // Pass hosts and nodes to Storage.
+    void update_nodes();
+    // Pass monitor_stats stuff.
+    void update_monitor_stats();
+    // Pass msgpacked metadata to Group objects (Round normally does it).
+    void update_metadata();
+    // Do update tasks normally performed by Round.
+    void update();
+
+    // Perform all actions above.
+    void update_all();
+
+private:
+    void add_node(rapidjson::Writer<rapidjson::StringBuffer> & writer,
+            const StorageSnapshot::Node & node);
+
+    static void add_backend(rapidjson::Writer<rapidjson::StringBuffer> & writer,
+            const StorageSnapshot::Backend & backend, const StorageSnapshot::FS & fs);
+
+    static void add_metadata(Group & st_group, const StorageSnapshot::Group & sn_group);
+    static void add_metadata_V1(Group & st_group, const StorageSnapshot::Group & sn_group);
+    static void add_metadata_V2(Group & st_group, const StorageSnapshot::Group & sn_group);
+
+private:
+    Storage & m_storage;
+    StorageSnapshot & m_snapshot;
+};
+
+#endif
+


### PR DESCRIPTION
The idea is to have an ability to describe test setup using minimalistic JSON document containing only key information about items. See detailed description in `StorageSnapshot.h` and `StorageUpdater.h`.
Example usage (not ready for merge yet): https://github.com/v-nikulichev/mastermind/commit/acf6aa303b03cbd3d18727455ceedac1561b431f
