### PR TITLE
Update snapshot JSON

### DIFF
--- a/src/collector/Backend.cpp
+++ b/src/collector/Backend.cpp
@@ -364,13 +364,13 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     //     "io_blocking_size": 0,
     //     "io_nonblocking_size": 0,
     //     "last_start": {
-    //         "ts_sec": 1444498430,
-    //         "ts_usec": 864588
+    //         "tv_sec": 1444498430,
+    //         "tv_usec": 864588
     //     },
     //     "max_blob_base_size": 2333049958,
     //     "max_read_rps": 100,
     //     "max_write_rps": 100,
-    //     "node": "::1:1025:10",
+    //     "node_id": "::1:1025:10",
     //     "read_ios": 89340,
     //     "read_only": false,
     //     "read_rps": 21,
@@ -378,7 +378,7 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     //     "records_removed": 2511,
     //     "records_removed_size": 258561169,
     //     "records_total": 29630,
-    //     "stalled": 0,
+    //     "stalled": false,
     //     "stat_commit_rofs_errors_diff": 0,
     //     "state": 1,
     //     "status": "OK",
@@ -414,11 +414,11 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     }
     writer.EndObject();
 
-    writer.Key("node");
+    writer.Key("node_id");
     writer.String(m_node.get_key().c_str());
     writer.Key("backend_id");
     writer.Uint64(m_stat.backend_id);
-    writer.Key("addr");
+    writer.Key("id");
     writer.String(m_key.c_str());
     writer.Key("state");
     writer.Uint64(m_stat.state);
@@ -456,6 +456,10 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     writer.Uint64(m_stat.blob_size);
     writer.Key("group");
     writer.Uint64(m_stat.group);
+    writer.Key("io_blocking_size");
+    writer.Uint64(m_stat.io_blocking_size);
+    writer.Key("io_nonblocking_size");
+    writer.Uint64(m_stat.io_nonblocking_size);
 
     writer.Key("vfs_free_space");
     writer.Uint64(m_calculated.vfs_free_space);
@@ -490,9 +494,9 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
 
     writer.Key("last_start");
     writer.StartObject();
-    writer.Key("ts_sec");
+    writer.Key("tv_sec");
     writer.Uint64(m_stat.last_start_ts_sec);
-    writer.Key("ts_usec");
+    writer.Key("tv_usec");
     writer.Uint64(m_stat.last_start_ts_usec);
     writer.EndObject();
 
@@ -508,7 +512,7 @@ void Backend::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
         writer.Key("stat_commit_rofs_errors");
         writer.Uint64(m_stat.stat_commit_rofs_errors);
         writer.Key("stalled");
-        writer.Uint64(m_calculated.stalled);
+        writer.Bool(m_calculated.stalled);
         writer.Key("data_path");
         writer.String(m_stat.data_path.c_str());
         writer.Key("file_path");

--- a/src/collector/Backend.h
+++ b/src/collector/Backend.h
@@ -147,6 +147,18 @@ public:
         BROKEN    // Misconfig
     };
 
+    enum class StatusDetail
+    {
+        Init = 0,
+        Stalled,
+        NotEnabled,
+        NoFS,
+        FSBroken,
+        ReadOnly,
+        HasCommitErrors,
+        OK
+    };
+
     static const char *status_str(Status status);
 
     struct Calculated
@@ -175,6 +187,7 @@ public:
         bool stalled;
 
         Status status;
+        StatusDetail status_detail;
 
         std::string base_path;
 

--- a/src/collector/FS.cpp
+++ b/src/collector/FS.cpp
@@ -47,6 +47,7 @@ FS::FS(Node & node, uint64_t fsid)
 {
     std::memset(&m_stat, 0, sizeof(m_stat));
     m_key = node.get_key() + "/" + std::to_string(fsid);
+    m_id = node.get_host().get_addr() + "/" + std::to_string(fsid);
 }
 
 FS::FS(Node & node)
@@ -65,6 +66,7 @@ void FS::clone_from(const FS & other)
 {
     m_fsid = other.m_fsid;
     m_key = other.m_key;
+    m_id = other.m_id;
     std::memcpy(&m_stat, &other.m_stat, sizeof(m_stat));
     m_calculated = other.m_calculated;
     m_status = other.m_status;
@@ -209,6 +211,7 @@ void FS::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
 {
     // JSON looks like this:
     // {
+    //     "id": "::1/158919948",
     //     "timestamp": {
     //         "tv_sec": 1445348936,
     //         "tv_usec": 615421,
@@ -220,7 +223,7 @@ void FS::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     //         "ell_net_read_rate": 0.0,
     //         "ell_net_write_rate": 0.0
     //     }
-    //     "node": "::1:1025:10",
+    //     "host_id": "::1",
     //     "fsid": 158919948,
     //     "total_space": 983547510784,
     //     "status": "OK",
@@ -228,6 +231,9 @@ void FS::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     // }
 
     writer.StartObject();
+
+    writer.Key("id");
+    writer.String(m_id.c_str());
 
     writer.Key("timestamp");
     writer.StartObject();
@@ -241,8 +247,8 @@ void FS::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
     }
     writer.EndObject();
 
-    writer.Key("node");
-    writer.String(m_node.get_key().c_str());
+    writer.Key("host_id");
+    writer.String(m_node.get_host().get_addr().c_str());
     writer.Key("fsid");
     writer.Uint64(m_fsid);
     writer.Key("status");

--- a/src/collector/FS.h
+++ b/src/collector/FS.h
@@ -127,6 +127,9 @@ private:
     uint64_t m_fsid;
     std::string m_key;
 
+    // 'id' field in JSON.
+    std::string m_id;
+
     // Set of references to backends stored on this filesystem. They shouldn't be
     // modified directly but only used to obtain related items and calculate the
     // state of the backend.

--- a/src/collector/Filter.h
+++ b/src/collector/Filter.h
@@ -32,7 +32,8 @@ struct Filter
         Node      = 8,
         Backend   = 0x10,
         FS        = 0x20,
-        Job       = 0x40
+        Job       = 0x40,
+        Host      = 0x80
     };
 
     Filter()

--- a/src/collector/FilterParser.cpp
+++ b/src/collector/FilterParser.cpp
@@ -107,6 +107,8 @@ bool FilterParser::String(const char* str, rapidjson::SizeType length, bool copy
             m_filter.item_types |= Filter::FS;
         else if (!std::strcmp(str, "job"))
             m_filter.item_types |= Filter::Job;
+        else if (!std::strcmp(str, "host"))
+            m_filter.item_types |= Filter::Host;
         else
             return false;
         break;

--- a/src/collector/Host.cpp
+++ b/src/collector/Host.cpp
@@ -41,13 +41,13 @@ void Host::print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer) const
 {
     // JSON looks like this:
     // {
-    //     "addr": "2001:cdba::3257:9652",
+    //     "id": "2001:cdba::3257:9652",
     //     "name": "node1.elliptics.mystorage.com",
     //     "dc": "changbu"
     // }
 
     writer.StartObject();
-    writer.Key("addr");
+    writer.Key("id");
     writer.String(m_addr.c_str());
     writer.Key("name");
     writer.String(m_name.c_str());

--- a/src/collector/Node.h
+++ b/src/collector/Node.h
@@ -112,10 +112,6 @@ public:
     void push_items(std::vector<std::reference_wrapper<FS>> & filesystems);
 
     void print_json(rapidjson::Writer<rapidjson::StringBuffer> & writer,
-            const std::vector<std::reference_wrapper<Backend>> & backends,
-            const std::vector<std::reference_wrapper<FS>> & filesystems,
-            bool print_backends,
-            bool print_fs,
             bool show_internals) const;
 
 public:

--- a/src/collector/Storage.h
+++ b/src/collector/Storage.h
@@ -46,6 +46,7 @@ public:
         std::vector<std::reference_wrapper<Node>> nodes;
         std::vector<std::reference_wrapper<FS>> filesystems;
         std::vector<std::reference_wrapper<Namespace>> namespaces;
+        std::vector<std::reference_wrapper<const Host>> hosts;
 
         void sort();
     };

--- a/tests/collector/filter_parser/filter_parser.cpp
+++ b/tests/collector/filter_parser/filter_parser.cpp
@@ -86,6 +86,7 @@ TEST(FilterParserTest, SingleItemType)
     test_item_types(vs({"backend"}), Filter::Backend);
     test_item_types(vs({"fs"}), Filter::FS);
     test_item_types(vs({"job"}), Filter::Job);
+    test_item_types(vs({"host"}), Filter::Host);
 }
 
 TEST(FilterParserTest, MultipleItemTypes)
@@ -103,8 +104,9 @@ TEST(FilterParserTest, AllItemTypes)
     // This test verifies parsing of item_types with all types specified.
 
     typedef std::vector<std::string> vs;
-    test_item_types(vs({"group", "couple", "namespace", "node", "backend", "fs", "job"}),
-            Filter::Group|Filter::Couple|Filter::Namespace|Filter::Node|Filter::Backend|Filter::FS|Filter::Job);
+    test_item_types(vs({"group", "couple", "namespace", "node", "backend", "fs", "job", "host"}),
+            Filter::Group|Filter::Couple|Filter::Namespace|Filter::Node|
+                Filter::Backend|Filter::FS|Filter::Job|Filter::Host);
 }
 
 TEST(FilterParserTest, WrongItemType)


### PR DESCRIPTION
- Key field of `Node`, `FS`, `Backend`, and `Host` objects is changed to `id`.
- Hosts, filesystems, and backends moved onto top level of the snapshot (they were nested in node).
- Added `FS` and `Node` field `host_id`.
- Added missing `io_blocking_size` and `io_nonblocking_size`.
- Added backend's `status_text`.
- s/ts_/tv_/ in `start_ts`.
