### PR TITLE
Enable dnet_recovery safe mode

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mastermind (2.25.120) trusty; urgency=medium
+
+  * Enable dnet_recovery safe mode
+
+ -- Andrey Vasilenkov <indigo@yandex-team.ru>  Sun, 28 Feb 2016 00:08:51 +0300
+
 mastermind (2.25.119) trusty; urgency=medium
 
   * Fix bug for dc hosts view

--- a/src/cocaine-app/infrastructure.py
+++ b/src/cocaine-app/infrastructure.py
@@ -74,7 +74,7 @@ class Infrastructure(object):
     DNET_RECOVERY_DC_CMD = (
         'dnet_recovery dc {remotes} -g {groups} -D {tmp_dir} '
         '-a {attempts} -b {batch} -l {log} -L {log_level} -n {processes_num} -M '
-        '-T {trace_id}'
+        '-T {trace_id} -S'
     )
     DNET_RECOVERY_DC_REMOTE_TPL = '-r {host}:{port}:{family}'
 


### PR DESCRIPTION
As of now, dnet_recovery seems to accidentally remove keys
that it should not. Turning on safe mode for now
to futher investigate the problem
