### PR TITLE
Add namespace attribute setitngs

### DIFF
--- a/src/mastermind
+++ b/src/mastermind
@@ -755,6 +755,16 @@ def ns_setup(namespace,
                  '',
                  'Allows namespace to use expire-time argument for signing url (1|0)'
              ),
+             attributes_capacity=(
+                 '',
+                 '',
+                 'Number of bytes to allocate for json section of a file (key)'
+             ),
+             attributes_filename=(
+                 '',
+                 '',
+                 "If this flag is 1, store filename of a key in key's attributes"
+             ),
              json=('', None, 'Format output as json'),
              host=None, app=None):
 
@@ -787,7 +797,10 @@ def ns_setup(namespace,
             select_couple_to_upload=select_couple_to_upload,
             reserved_space_percentage=reserved_space_percentage,
             check_for_update=check_for_update,
-            custom_expiration_time=custom_expiration_time)
+            custom_expiration_time=custom_expiration_time,
+            attributes_capacity=attributes_capacity,
+            attributes_filename=attributes_filename == '1',
+        )
 
     else:
         ns = cl.namespaces[namespace]
@@ -868,6 +881,15 @@ def ns_setup(namespace,
 
         if check_for_update:
             settings['check-for-update'] = check_for_update != '0'
+
+        attributes = {}
+        if attributes_capacity:
+            attributes['capacity'] = int(attributes_capacity)
+        if attributes_filename:
+            attributes['filename'] = attributes_filename == '1'
+
+        if attributes:
+            settings['attributes'] = attributes
 
         if overwrite:
             ns.settings = settings

--- a/src/python-mastermind/src/mastermind/query/namespaces.py
+++ b/src/python-mastermind/src/mastermind/query/namespaces.py
@@ -67,7 +67,9 @@ class NamespacesQuery(Query):
               select_couple_to_upload=None,
               reserved_space_percentage=None,
               check_for_update=None,
-              custom_expiration_time=None):
+              custom_expiration_time=None,
+              attributes_capacity=None,
+              attributes_filename=None):
         """Performs initial namespace setup.
 
         Args:
@@ -108,6 +110,8 @@ class NamespacesQuery(Query):
             if does not exists already
           custom_expiration_time: allows namespace to use expire-time argument
             for signing url
+          attributes_capacity: number of bytes to allocate for json section of a file (key)
+          attributes_filename: if this flag is True, store filename of a key in key's attributes
 
         Returns:
           Namespace object representing created namespace.
@@ -176,6 +180,15 @@ class NamespacesQuery(Query):
 
         if check_for_update:
             settings['check-for-update'] = check_for_update != '0'
+
+        attributes = {}
+        if attributes_capacity:
+            attributes['capacity'] = int(attributes_capacity)
+        if attributes_filename:
+            attributes['filename'] = attributes_filename is True
+
+        if attributes:
+            settings['attributes'] = attributes
 
         ns_data = self.client.request('namespace_setup', [namespace, True, settings, {}])
 


### PR DESCRIPTION
Attributes are written to key's json and allow
to store key's metadata. This commit enables
two namespace settings:
    attributes capacity - how many bytes are reserved for a key's json
    attributes filename - if filename should be stored in key's attributes
