### PR TITLE
Prevent application from running when inventory module cannot be impo…

### DIFF
--- a/src/cocaine-app/inventory.py
+++ b/src/cocaine-app/inventory.py
@@ -4,7 +4,12 @@ from importer import import_object
 
 try:
     inv = import_object(config['inventory'])
-except (ImportError, KeyError):
+except ImportError as e:
+    raise RuntimeError('Failed to import inventory module {inventory}: {error}'.format(
+        inventory=config['inventory'],
+        error=e,
+    ))
+except KeyError:
     import fake_inventory as inv
 
 get_dc_by_host = inv.get_dc_by_host


### PR DESCRIPTION
…rted

Previously inventory module could be replaced by 'fake_inventory'
as a fallback if it could not be imported. This could lead to
nasty undesirable side-effects and should not be allowed.
Now we do not allow the application to start if inventory
module was misconfigured
