### PR TITLE
Add couple settings

### DIFF
--- a/examples/mastermind.conf
+++ b/examples/mastermind.conf
@@ -86,6 +86,10 @@
             "wtimeout": 5000
         },
 
+        "couples": {
+            "db": "mastermind_couples"
+        },
+
         "jobs": {
             "db": "mastermind_jobs"
         },

--- a/src/cocaine-app/couple_records.py
+++ b/src/cocaine-app/couple_records.py
@@ -1,0 +1,124 @@
+from config import config
+from db.mongo import MongoObject
+from db.mongo.pool import Collection
+from mastermind_core import helpers
+import storage
+
+
+class CoupleRecord(MongoObject):
+
+    ID = 'id'
+    SETTINGS = 'settings'
+
+    PRIMARY_ID_KEY = ID
+
+    def __init__(self, **init_params):
+        super(CoupleRecord, self).__init__()
+
+        self.couple_id = init_params[self.ID]
+        self.settings = init_params.get(self.SETTINGS, {})
+
+    @property
+    def id(self):
+        return self.couple_id
+
+    @classmethod
+    def new(cls, **kwargs):
+        couple_record = cls(**kwargs)
+        couple_record._dirty = True
+        return couple_record
+
+    def set_settings(self, settings, update=True):
+        if update:
+            old_settings = self.settings
+        else:
+            old_settings = {}
+        new_settings = helpers.merge_dict(old_settings, settings)
+        CoupleSettingsValidator.validate_settings(new_settings)
+        self.settings = new_settings
+        self._dirty = True
+
+    def dump(self):
+        return {
+            'id': self.id,
+            'settings': self.settings,
+        }
+
+
+class CoupleSettingsValidator(object):
+
+    @staticmethod
+    def validate_settings(settings):
+        if storage.Couple.READ_PREFERENCE not in settings:
+            raise ValueError('Couple requires "read_preference" setting')
+        for setting_name, setting in settings.iteritems():
+            if setting_name == storage.Couple.READ_PREFERENCE:
+                CoupleSettingsValidator._validate_read_preference(
+                    settings[storage.Couple.READ_PREFERENCE]
+                )
+            else:
+                raise ValueError('Invalid couple setting: "{}"'.format(setting_name))
+
+    @staticmethod
+    def _validate_read_preference(rp_settings):
+        if not isinstance(rp_settings, (tuple, list)):
+            raise ValueError('"read_preference" is "{type}", expected a list or a tuple'.format(
+                type=type(rp_settings).__name__,
+            ))
+
+        unique_rp = set()
+        for read_preference in rp_settings:
+            if read_preference not in storage.GROUPSET_IDS:
+                raise ValueError('Invalid groupset id: {}'.format(read_preference))
+            if read_preference in unique_rp:
+                raise ValueError(
+                    'Read preference should contain unique list of groupset ids, '
+                    'value "{value}" is found more than once'.format(
+                        value=read_preference,
+                    )
+                )
+            unique_rp.add(read_preference)
+
+
+class CoupleRecordNotFoundError(Exception):
+    pass
+
+
+class CoupleRecordFinder(object):
+    def __init__(self, db):
+        self.collection = Collection(db[config['metadata']['couples']['db']], 'couples')
+
+    def _get_couple_record(self, couple):
+        couple_id = couple.as_tuple()[0]
+        couple_records_list = (
+            self.collection
+            .list(**{CoupleRecord.ID: couple_id})
+            .limit(1)
+        )
+        try:
+            couple_record = CoupleRecord(**couple_records_list[0])
+        except IndexError:
+            raise CoupleRecordNotFoundError(
+                'Couple record for couple {} is not found'.format(couple_id)
+            )
+        couple_record.collection = self.collection
+        return couple_record
+
+    def couple_record(self, couple):
+        try:
+            return self._get_couple_record(couple)
+        except CoupleRecordNotFoundError:
+            couple_id = couple.as_tuple()[0]
+            couple_record = CoupleRecord.new(**{CoupleRecord.ID: couple_id})
+            couple_record.collection = self.collection
+            return couple_record
+
+    def couple_records(self, ids=None):
+        records = [
+            CoupleRecord(**gh)
+            for gh in self.collection.list(id=ids)
+        ]
+        for r in records:
+            r.collection = self.collection
+            r._dirty = False
+        return records

--- a/src/cocaine-app/mastermind_core/helpers.py
+++ b/src/cocaine-app/mastermind_core/helpers.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import cStringIO
 import gzip
 
@@ -14,6 +15,7 @@ def gzip_compress(data, compression_level=1):
             gz.write(data)
         return buf.getvalue()
 
+
 def encode(s, encoding='utf-8', errors='strict'):
     """Returns an encoded version of string
 
@@ -23,3 +25,18 @@ def encode(s, encoding='utf-8', errors='strict'):
     if isinstance(s, unicode):
         return s.encode(encoding, errors=errors)
     return s
+
+
+def merge_dict(dst, src):
+    """ Merges two dicts updating 'dst' keys with those from 'src'
+    """
+    res = copy.deepcopy(dst)
+    for k, val in src.iteritems():
+        if k not in dst:
+            res[k] = val
+        else:
+            if not isinstance(val, dict):
+                res[k] = val
+            else:
+                res[k] = merge_dict(res[k], src[k])
+    return res

--- a/src/mastermind
+++ b/src/mastermind
@@ -424,6 +424,39 @@ def couple_info(group, host=None, app=None):
     pprint(res)
 
 
+@coupleDispatcher.command(name='settings')
+@log_action
+def couple_settings(couple_id,
+                    overwrite=('o', False, 'Flag to setup couple settings from scratch'),
+                    read_preference=(
+                        '',
+                        [],
+                        'Read preference for couple (can be used multiple times to set '
+                        'read preference list, e.g "--read-preference replicas '
+                        '--read-preference lrc-8-2-2v1")'),
+                    host=None,
+                    app=None):
+    '''Update couple settings'''
+    cl = client(host, app)
+
+    settings = {}
+    if read_preference:
+        settings['read_preference'] = read_preference
+
+    try:
+        group_id = int(couple_id)
+    except (ValueError, TypeError):
+        group_id = None
+
+    couple = cl.groups[group_id].couple
+    if overwrite:
+        couple.settings = settings
+    else:
+        couple.settings.update(settings)
+
+    print True
+
+
 STATES = {
     'OK': 'good',
     'FULL': 'full',

--- a/src/python-mastermind/src/mastermind/query/couples.py
+++ b/src/python-mastermind/src/mastermind/query/couples.py
@@ -65,6 +65,113 @@ class CouplesQuery(Query):
 
 
 class CoupleDataObject(LazyDataObject):
+    # TODO: this code almost completely repeats NamespaceDataObject.Settings,
+    # should be generalized
+    class Settings(object):
+        def __init__(self, client, couple, settings, levels=None):
+            self._client = client
+            self._couple = couple
+            self._settings = settings
+            self._levels = levels or []
+
+        def __getitem__(self, key):
+            return CoupleDataObject.Settings(
+                client=self._client,
+                couple=self._couple,
+                settings=self._settings[key],
+                levels=self._levels + [key]
+            )
+
+        def __setitem__(self, key, value):
+            settings = {key: value}
+            for level in reversed(self._levels):
+                settings = {level: settings}
+            self._client.request(
+                'update_couple_settings',
+                {
+                    'couple': self._couple.id,
+                    'settings': settings,
+                    'update': True,
+                }
+            )
+            self._couple._expire()
+
+        def update(self, value):
+            settings = value
+            for level in reversed(self._levels):
+                settings = {level: settings}
+            self._client.request(
+                'update_couple_settings',
+                {
+                    'couple': self._couple.id,
+                    'settings': settings,
+                    'update': True,
+                }
+            )
+            self._couple._expire()
+
+        def __repr__(self):
+            return repr(self._settings)
+
+        def __str__(self):
+            return str(self._settings)
+
+        def __contains__(self, key):
+            return key in self._settings
+
+        def __len__(self):
+            return len(self._settings)
+
+        def __eq__(self, other):
+            if isinstance(other, CoupleDataObject.Settings):
+                return self._settings == other._settings
+            return self._settings == other
+
+        def __ne__(self, other):
+            return not self == other
+
+        def keys(self):
+            return self._settings.keys()
+
+        def values(self):
+            return [v for _, v in self.items()]
+
+        def items(self):
+            return [
+                (
+                    k,
+                    CoupleDataObject.Settings(
+                        client=self._client,
+                        couple=self._couple,
+                        settings=v,
+                        levels=self._levels + [k]
+                    )
+                )
+                for k, v in self._settings.iteritems()
+            ]
+
+        def iterkeys(self):
+            return self._settings.iterkeys()
+
+        def itervalues(self):
+            for _, v in self.iteritems():
+                yield v
+
+        def iteritems(self):
+            for k, v in self._settings.iteritems():
+                yield (
+                    k,
+                    CoupleDataObject.Settings(
+                        client=self._client,
+                        couple=self._couple,
+                        settings=v,
+                        levels=self._levels + [k]
+                    )
+                )
+
+        def dict(self):
+            return self._settings
+
     def __init__(self, *args, **kwargs):
         super(CoupleDataObject, self).__init__(*args, **kwargs)
         self._stats = None
@@ -131,7 +238,7 @@ class CoupleDataObject(LazyDataObject):
     def read_preference(self):
         """ Couple's groupset read preference
         """
-        return self._data['read_preference']
+        return self.settings['read_preference']
 
     @property
     @LazyDataObject._lazy_load
@@ -173,6 +280,25 @@ class CoupleDataObject(LazyDataObject):
         }
         data['groupsets'] = groupsets
         return data
+
+    @property
+    @LazyDataObject._lazy_load
+    def settings(self):
+        return CoupleDataObject.Settings(self.client, self, self._data['settings'])
+
+    @settings.setter
+    def settings(self, new_settings):
+        if isinstance(new_settings, CoupleDataObject.Settings):
+            new_settings = new_settings.dict()
+        self.client.request(
+            'update_couple_settings',
+            {
+                'couple': self.id,
+                'settings': new_settings,
+                'update': False,
+            }
+        )
+        self._expire()
 
 
 GOOD_STATUSES = set(['OK', 'FULL', 'FROZEN'])


### PR DESCRIPTION
This commit adds couple settings that are stored in meta database
(mongodb).
Right now these settings include 'read_preference' that
clients should use to get access to data stored in the couple.
This commit also includes all required API handles and
python binding objects to access and alter these settings.
