### PR TITLE
A new job in mastermind that removes records with expired ttl

### DIFF
--- a/src/cocaine-app/__init__.py
+++ b/src/cocaine-app/__init__.py
@@ -246,6 +246,7 @@ def init_planner(job_processor, niu):
     register_handle(planner.move_groups_from_host)
     register_handle(planner.convert_external_storage_to_groupset)
     register_handle(planner.restore_groups_from_path)
+    register_handle(planner.ttl_cleanup)
     return planner
 
 

--- a/src/cocaine-app/jobs/__init__.py
+++ b/src/cocaine-app/jobs/__init__.py
@@ -48,6 +48,7 @@ class JobProcessor(object):
     JOB_PRIORITIES = {
         JobTypes.TYPE_RESTORE_GROUP_JOB: 25,
         JobTypes.TYPE_MOVE_JOB: 20,
+        JobTypes.TYPE_TTL_CLEANUP_JOB: 19,
         JobTypes.TYPE_ADD_LRC_GROUPSET_JOB: 17,
         JobTypes.TYPE_CONVERT_TO_LRC_GROUPSET_JOB: 17,
         JobTypes.TYPE_RECOVER_DC_JOB: 15,
@@ -60,6 +61,7 @@ class JobProcessor(object):
     SUPPORTED_JOBS = set([
         JobTypes.TYPE_RESTORE_GROUP_JOB,
         JobTypes.TYPE_MOVE_JOB,
+        JobTypes.TYPE_TTL_CLEANUP_JOB,
         JobTypes.TYPE_RECOVER_DC_JOB,
         JobTypes.TYPE_COUPLE_DEFRAG_JOB,
         JobTypes.TYPE_MAKE_LRC_GROUPS_JOB,

--- a/src/cocaine-app/jobs/job_factory.py
+++ b/src/cocaine-app/jobs/job_factory.py
@@ -6,7 +6,7 @@ from restore_group import RestoreGroupJob
 from make_lrc_groups import MakeLrcGroupsJob
 from add_lrc_groupset import AddLrcGroupsetJob
 from convert_to_lrc_groupset import ConvertToLrcGroupsetJob
-
+from ttl_cleanup import TtlCleanupJob
 
 class JobFactory(object):
 
@@ -26,6 +26,8 @@ class JobFactory(object):
             return AddLrcGroupsetJob
         elif job_type == JobTypes.TYPE_CONVERT_TO_LRC_GROUPSET_JOB:
             return ConvertToLrcGroupsetJob
+        elif job_type == JobTypes.TYPE_TTL_CLEANUP_JOB:
+            return TtlCleanupJob
         raise ValueError('Unknown job type: {}'.format(job_type))
 
     @staticmethod

--- a/src/cocaine-app/jobs/job_types.py
+++ b/src/cocaine-app/jobs/job_types.py
@@ -7,6 +7,7 @@ class JobTypes(object):
     TYPE_MAKE_LRC_GROUPS_JOB = 'make_lrc_groups_job'
     TYPE_ADD_LRC_GROUPSET_JOB = 'add_lrc_groupset_job'
     TYPE_CONVERT_TO_LRC_GROUPSET_JOB = 'convert_to_lrc_groupset_job'
+    TYPE_TTL_CLEANUP_JOB = 'ttl_cleanup_job'
 
     AVAILABLE_TYPES = (
         TYPE_MOVE_JOB,

--- a/src/cocaine-app/jobs/ttl_cleanup.py
+++ b/src/cocaine-app/jobs/ttl_cleanup.py
@@ -1,0 +1,96 @@
+import tasks
+from job import Job
+from job_types import JobTypes
+import logging
+import storage
+from infrastructure import infrastructure
+
+logger = logging.getLogger('mm.jobs')
+
+
+class TtlCleanupJob(Job):
+
+    PARAMS = (
+        'iter_group',
+        'batch_size',
+        'attempts',
+        'nproc',
+        'wait_timeout',
+        'dry_run',
+        'resources'
+    )
+
+    def __init__(self, **kwargs):
+        super(TtlCleanupJob, self).__init__(**kwargs)
+        self.type = JobTypes.TYPE_TTL_CLEANUP_JOB
+
+    def _set_resources(self):
+        self.resources = {
+            Job.RESOURCE_HOST_IN: [],
+            Job.RESOURCE_HOST_OUT: [],
+            Job.RESOURCE_FS: [],
+        }
+
+        # Addressing self.iter_group is more or less safe here since
+        # set resources is raised soon after initialization
+        # and on initialization iter_group is validated
+
+        # The nodes that are not iterated would be asked to perform remove
+        # operation. No data is written. And no data is read.
+        # While iteration group node is working heavily
+        nb = storage.groups[self.iter_group].node_backends[0]
+        self.resources[Job.RESOURCE_HOST_IN].append(nb.node.host.addr)
+        self.resources[Job.RESOURCE_FS].append((nb.node.host.addr, str(nb.fs.fsid)))
+
+    def create_tasks(self, processor):
+
+        # Addressing by iter_group may cause an exception of mm was restared
+        # or group disappeared. But it is better to handle exceptions
+        # and manually restart the job then simply ignore undone work
+        iter_group_desc = storage.groups[self.iter_group]
+        couple = iter_group_desc.couple
+        groups = []
+        remotes = []
+        for g in couple.groups:
+            groups.append(g.group_id)
+            node = g.node_backends[0].node
+            remotes.append("{}:{}:{}".format(node.host.addr, node.port, node.family))
+
+        # Log, Log_level, temp to be taken from config on infrastructure side
+        ttl_cleanup_cmd = infrastructure.ttl_cleanup_cmd(
+            remotes=remotes,
+            groups=groups,
+            iter_group=self.iter_group,
+            wait_timeout=self.wait_timeout,
+            batch_size=self.batch_size,
+            attempts=self.attempts,
+            nproc=self.nproc,
+            trace_id=int(self.id[:16], 16),
+            safe=self.dry_run)
+
+        logger.debug("TTl cleanup job: Set for execution task %s", ttl_cleanup_cmd)
+
+        # Run langolier on the storage node where we are going to iterate
+        nb = iter_group_desc.node_backends[0]
+        host = nb.node.host.addr
+        task = tasks.MinionCmdTask.new(
+            self,
+            host=host,
+            group=self.iter_group,
+            cmd=ttl_cleanup_cmd,
+            params={},
+        )
+        self.tasks.append(task)
+
+    @property
+    def _involved_groups(self):
+        # Addressing by iter_group may cause an exception of mm was restared
+        # or group disappeared. But it is better to handle exceptions
+        # and manually restart the job then simply ignore undone work
+        couple = storage.groups[self.iter_group].couple
+        return [g.group_id for g in couple.groups]
+
+    @property
+    def _involved_couples(self):
+        # Addressing by iter_group may cause an exception. See comment in _involved_groups
+        return [str(storage.groups[self.iter_group].couple)]

--- a/src/mastermind
+++ b/src/mastermind
@@ -1850,6 +1850,36 @@ def lrc_groupset_convert(groupset=('g',
     return
 
 
+@coupleDispatcher.command(name='ttl_cleanup')
+@log_action
+def ttl_cleanup(iter_group, 
+                batch_size=('b', '', 'The batch size (a number of records to be removed simultaneously)'),
+                attempts=('a', '', 'The retry count'),
+                nproc=('n', '', 'A number of threads in session'),
+                wait_timeout=('w', '', 'Timeout for elliptics operations'),
+                dry_run=('d', False, 'Dry-run mode'),
+                host=None, app=None):
+    '''
+    Remove records with TTL expired
+    '''
+    s = service(host, app)
+
+    iter_group = int(iter_group)
+
+    params = {
+        'iter_group': iter_group,
+        'batch_size': batch_size,
+        'attempts': attempts,
+        'nproc': nproc,
+        'wait_timeout': wait_timeout,
+        'dry_run': dry_run
+        }
+
+    res = s.enqueue('ttl_cleanup', msgpack.packb(params)).get()
+
+    print res
+    return
+
 d = Dispatcher(globaloptions=(app_param,))
 d.nest('group', groupDispatcher, 'Perform group action')
 d.nest('couple', coupleDispatcher, 'Perform couple action')
@@ -1859,7 +1889,6 @@ d.nest('job', jobDispatcher, 'Perform jobs action')
 d.nest('lock', lockDispatcher, 'Acquire locks on storage infrastructure nodes')
 d.nest('unlock', unlockDispatcher, 'Release locks on storage infrastructure nodes')
 d.nest('lrc', lrcDispatcher, 'Perform actions with LRC groups or couples')
-
 
 def command_helper(argv):
     cmdtable = d.cmdtable


### PR DESCRIPTION
Run mds_cleanup from langolier package in mastermind-minion

Could be run in mastermind-cli via "couple ttl_cleanup"
Accepts iteration group, while other params could be either obtained from config
or defaults to mds_cleanup. iter_group in this job is "unpacked" into a list of
groups and remotes for all other members of the couple where iter_group belongs.
