### PR TITLE
Skip pending jobs' resources

### DIFF
--- a/src/cocaine-app/jobs/__init__.py
+++ b/src/cocaine-app/jobs/__init__.py
@@ -107,7 +107,13 @@ class JobProcessor(object):
 
     def _ready_jobs(self):
 
-        active_jobs = self.job_finder.jobs(statuses=Job.ACTIVE_STATUSES)
+        active_statuses = Job.ACTIVE_STATUSES
+
+        # TEMP: do not account broken/pending jobs' resources
+        active_statuses.remove(Job.STATUS_PENDING)
+        active_statuses.remove(Job.STATUS_BROKEN)
+
+        active_jobs = self.job_finder.jobs(statuses=active_statuses)
 
         ready_jobs = []
         new_jobs = []


### PR DESCRIPTION
The list of pending and broken recover dc and defragmentation jobs
happens to be non-empty all the time, and investigation takes a lot of time
while new jobs are being on hold.
As for now, we want to defarg and recover as fast as we can, so broken and
pending jobs' resources should not be accounted for when jobs are being
scheduled.
