### PR TITLE
TTL cleanup scheduler. v0.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Depends:
  python-tornado (>= 4.0),
  cocaine-framework-python (<< 0.12),
  python-simplejson,
+ yandex-yql-python,
 Conflicts:
  python-mastermind
 Description: Common components and a client library for Mastermind

--- a/examples/mastermind.conf
+++ b/examples/mastermind.conf
@@ -177,6 +177,19 @@
             "autoapprove": True
         },
 
+        "ttl_cleanup": {
+            "enabled": true,
+            "aggregation_table": "",
+            "tskv_log_table": "",
+            "ttl_cleanup_period": 9000,
+            "yt_cluster": "",
+            "yt_token": "",
+            "yt_attempts": 5,
+            "yt_delay": 900,
+            "autoapprove": true,
+            "ttl_threshold": 1000
+        },
+
         "external_storage_converting": {
             "enabled": true,
             "generate_plan_period": 1800,
@@ -314,7 +327,15 @@
             "attempts": 1,
             "log": "lrc_validate.log",
             "log_level": 1
-        }
+        },
+        "ttl_cleanup":{
+            "attempts": 5,
+            "nproc": 5,
+            "batch_size": 30,
+            "log": 'ttl_cleanup.log',
+            "tmp_dir": '/var/tmp/',
+            "tskv_log_file": 'syslog'
+        },
     },
 
     "inventory_cache": {

--- a/src/cocaine-app/planner/__init__.py
+++ b/src/cocaine-app/planner/__init__.py
@@ -1438,6 +1438,7 @@ class Planner(object):
 
         return candidates[0]
 
+    @h.concurrent_handler
     def ttl_cleanup(self, request):
         """
         TTL cleanup job. Remove all records with expired TTL

--- a/src/cocaine-app/planner/__init__.py
+++ b/src/cocaine-app/planner/__init__.py
@@ -19,6 +19,7 @@ from mastermind_core.db.mongo.pool import Collection
 from sync import sync_manager
 from sync.error import LockFailedError, LockAlreadyAcquiredError
 from timer import periodic_timer
+from yt_worker import YqlWrapper
 
 import timed_queue
 
@@ -30,11 +31,13 @@ class Planner(object):
     MOVE_CANDIDATES = 'move_candidates'
     RECOVER_DC = 'recover_dc'
     COUPLE_DEFRAG = 'couple_defrag'
+    TTL_CLEANUP = 'ttl_cleanup'
 
     RECOVERY_OP_CHUNK = 200
 
     COUPLE_DEFRAG_LOCK = 'planner/couple_defrag'
     RECOVER_DC_LOCK = 'planner/recover_dc'
+    TTL_CLEANUP_LOCK = 'planner/ttl_cleanup'
 
     def __init__(self, db, niu, job_processor, namespaces_settings):
 
@@ -55,6 +58,8 @@ class Planner(object):
         self.couple_defrag_timer = periodic_timer(
             seconds=self.params.get('couple_defrag', {}).get(
                 'couple_defrag_period', 60 * 15))
+        self.ttl_cleanup_timer = periodic_timer(
+            seconds=self.params.get('ttl_cleanup', {}).get('ttl_cleanup_period', 60 * 15))
 
         if config['metadata'].get('planner', {}).get('db'):
             self.collection = Collection(db[config['metadata']['planner']['db']], 'planner')
@@ -73,11 +78,96 @@ class Planner(object):
                     self._couple_defrag
                 )
 
+            if self.params.get('ttl_cleanup', {}).get('enabled', False):
+                self.__tq.add_task_at(
+                    self.TTL_CLEANUP,
+                    self.ttl_cleanup_timer.next(),
+                    self._ttl_cleanup_planner
+                )
+
     def _start_tq(self):
         self.__tq.start()
 
     def add_planner(self, planner):
         planner.schedule_tasks(self.__tq)
+
+    def _get_yt_stat(self):
+        """
+        Extract statistics from YT logs
+        :return: list of couples ids with expired records volume above specified
+        """
+        try:
+            # Configure parameters for work with YT
+            yt_cluster = self.params.get('ttl_cleanup', {}).get('yt_cluster', "")
+            yt_token = self.params.get('ttl_cleanup', {}).get('yt_token', "")
+            yt_attempts = self.params.get('ttl_cleanup', {}).get('yt_attempts', 3)
+            yt_delay = self.params.get('ttl_cleanup', {}).get('yt_delay', 10)
+
+            yt_wrapper = YqlWrapper(cluster=yt_cluster, token=yt_token, attempts=yt_attempts, delay=yt_delay)
+
+            aggregation_table = self.params.get('ttl_cleanup', {}).get('aggregation_table', "")
+            base_table = self.params.get('ttl_cleanup', {}).get('tskv_log_table', "")
+            expired_threshold = self.params.get('ttl_cleanup', {}).get('ttl_threshold', 10 * float(1024 ** 3))  # 10GB
+
+            yt_wrapper.prepare_aggregate_for_yesterday(base_table, aggregation_table)
+
+            couple_list = yt_wrapper.request_expired_stat(aggregation_table, expired_threshold)
+            logger.info("YT request has completed")
+            return couple_list
+        except:
+            logger.exception("Work with YQL failed")
+            return []
+
+    def _ttl_cleanup_planner(self):
+        try:
+            logger.info('Starting ttl cleanup planner')
+
+            with sync_manager.lock(Planner.TTL_CLEANUP_LOCK, blocking=False):
+                self._do_ttl_cleanup()
+
+        except LockFailedError:
+            logger.info('TTl cleanup planner is already running')
+        except Exception as e:
+            logger.exception('Failed to plan ttl cleanup')
+        finally:
+            logger.info('TTL cleanup planner finished')
+            self.__tq.add_task_at(
+                self.TTL_CLEANUP,
+                self.ttl_cleanup_timer.next(),
+                self._ttl_cleanup_planner)
+
+    def _do_ttl_cleanup(self):
+        logger.info('Run ttl cleanup')
+
+        couple_list = self._get_yt_stat()
+        for couple in couple_list:
+
+            iter_group = couple #in tskv coupld id is actually group[0] from couple id
+            if iter_group not in storage.groups:
+                logger.error("Not valid group is extracted from aggregation log {}".format(iter_group))
+                continue
+            iter_group = storage.groups[iter_group]
+            if not iter_group.couple:
+                logger.error("Iter group is uncoupled {}".format(str(iter_group)))
+                continue
+
+            try:
+                job = self.job_processor._create_job(
+                    job_type=jobs.JobTypes.TYPE_TTL_CLEANUP_JOB,
+                    params={
+                        'iter_group': iter_group.group_id,
+                        'couple': str(iter_group.couple),
+                        'namespace': iter_group.couple.namespace.id,
+                        'batch_size': None, #get from config
+                        'attempts': None, #get from config
+                        'nproc': None, #get from config
+                        'wait_timeout': None, #get from config
+                        'dry_run': False,
+                        'need_approving': not self.params.get('ttl_cleanup', {}).get('autoapprove', False),
+                        },
+                    )
+            except:
+                logger.exception("Creating job for iter group {} has excepted".format(iter_group))
 
     @staticmethod
     def _prepare_candidates_by_dc(suitable_groups, unsuitable_dcs):
@@ -1415,6 +1505,8 @@ class Planner(object):
             )
 
         iter_group = storage.groups[request['iter_group']]
+        if not iter_group.couple:
+            raise RuntimeError('Group is uncoupled? {}'.format(str(iter_group)))
 
         job = self.job_processor._create_job(
             job_type=jobs.JobTypes.TYPE_TTL_CLEANUP_JOB,
@@ -1429,6 +1521,7 @@ class Planner(object):
                 'dry_run': request.get('dry_run'),
                 'remove_all_older': remove_all_older,
                 'remove_permanent_older': remove_permanent_older,
+                'need_approving': request.get('need_approving'),
             },
         )
 

--- a/src/cocaine-app/yt_worker.py
+++ b/src/cocaine-app/yt_worker.py
@@ -1,0 +1,198 @@
+from logging import getLogger
+from yql.api.v1.client import YqlClient
+import time
+import datetime
+
+
+logger = getLogger('mm.planner')
+
+
+class YqlWrapper(object):
+
+    VALIDATE_QUERY = """
+        SELECT
+          COUNT(*)
+        FROM [{table}]
+        WHERE source_table="{date_iso}";
+    """
+
+    # XXX: maybe something more optimal could be done? How the db is organized?
+    # XXX: tounixdate -> arithmetic ops
+    # XXX: use HAVING ?
+    PREAGGREGATE_QUERY = """
+$dateconv = @@
+import time
+import datetime
+def tounixdate(exp_time):
+    return int(time.mktime((datetime.date.fromtimestamp(exp_time) + datetime.timedelta(days=1)).timetuple()))
+@@;
+
+$dateconvert = Python::tounixdate("(Uint64?)->Uint64", $dateconv);
+
+INSERT INTO [{agr_table}]
+SELECT
+    couple_id,
+    expiration_date,
+    namespace,
+    "upload" AS operation,
+    SUM(CAST(object_size AS Int64)) AS expired_size,
+    "{date_iso}" AS source_table,
+    {timestamp} AS timestamp
+FROM [{main_table}]
+WHERE op="upload"
+GROUP BY
+    couple_id,
+    namespace,
+    $dateconvert(CAST(expire_at AS Uint64)) AS expiration_date;
+
+INSERT INTO [{agr_table}]
+SELECT
+    couple_id,
+    expiration_date,
+    namespace,
+    "delete" AS operation,
+    -1*SUM(CAST(object_size AS Int64)) AS expired_size,
+    "{date_iso}" AS source_table,
+    {timestamp} AS timestamp
+FROM [{main_table}]
+WHERE op="delete" AND expire_at IS NOT NULL
+GROUP BY
+    couple_id,
+    namespace,
+    $dateconvert(CAST(expire_at AS Uint64)) AS expiration_date;
+        """
+
+    AGGREGATE_QUERY = """
+        SELECT couple_id
+        FROM
+            (SELECT
+                couple_id,
+                SUM(expired_size) AS sum_expired_size
+            FROM [{table}]
+            WHERE expiration_date <= {timestamp}
+            GROUP BY couple_id)
+        WHERE  sum_expired_size >= {trigger};
+    """
+
+    def __init__(self, cluster, token, attempts, delay):
+        self._cluster = cluster
+        self._token = token
+        self._attempts = attempts
+        self._delay = delay
+
+    def send_request(self, query, timeout=None):
+        """
+        Send request to YQL: ping verification + attempts retry
+        @return result dict on success, excepts otherwise
+        """
+        logger.debug('Send YQL request {}'.format(query))
+        result = None
+
+        with YqlClient(db=self._cluster, token=self._token) as yql:
+            if not yql.ping():
+                raise IOError("YQL ping failed {} {}".format(self._cluster, self._token[:20]))
+
+            for attempt in xrange(self._attempts):
+                try:
+                    start_time = time.time()
+
+                    request = yql.query(query)
+                    request = request.run()
+                    logger.info("YQL query is running with id {}".format(request.operation_id))
+                    result = request.results
+                    end_time = time.time()
+                    if result.is_success:
+                        logger.info("YQL query succeeded and took {}".format(end_time-start_time))
+                        if timeout and (end_time - start_time > timeout):
+                            # XXX: need to add this condition into monitoring
+                            # Do not except here - after all we already have some successful result
+                            logger.error("YQL query({}..{}) > timeout {}".format(start_time, end_time, timeout))
+                        return result
+
+                    logger.error("YQL failed #{}: {}[{}] ({},{})".format(attempt, result.status,
+                                 request.status_code, request.explain(), str(request.exc_info)))
+                    for error in result.errors:
+                        logger.error("YQL query result error {}".format(str(error)))
+
+                    time.sleep(self._delay)
+                except:
+                    logger.exception("YQL request excepted")
+                    continue  # give one more chance
+
+        raise RuntimeError("YQL request attempts has exhausted {} {}".format(self._attempts, query))
+
+
+    def request_expired_stat(self, aggregate_table, expired_threshold, timeout=None):
+        """
+        Send request to aggregate table to find volume of expired space in couples
+        :param aggregate_table: the name of aggregation table
+        :param expired_threshold: couples with expired volume above the param would be returned
+        :return list of couple ids with expired data more than trigger
+        """
+
+        timestamp = int(time.time())
+        query = self.AGGREGATE_QUERY.format(table=aggregate_table, timestamp=timestamp, trigger=expired_threshold)
+
+        try:
+            r = self.send_request(query, timeout)
+            if r.rows_count == 0:
+                # it is quite suspicious that we haven't found anything. Maybe wrong table?
+                logger.warning("empty result for table {} and trigger {}".format(aggregate_table, expired_threshold))
+                return []
+        except:
+            logger.exception("YT request excepted")
+            return []
+
+        valid_couples = []
+
+        for table in r.results:  # access to results blocks until they are ready
+            table.fetch_full_data()
+            for row in table.rows:
+                try:
+                    couple = int(row[0])
+                except ValueError:
+                    logger.exception("couple {} is invalid".format(str(row[0])))
+                else:
+                    logger.debug("couple {} is valid".format(couple))
+                    valid_couples.append(couple)
+
+        return valid_couples
+
+    def prepare_aggregate_for_yesterday(self, base_table, aggregate_table):
+        """
+        Update aggregate table from YT with data from yesterday logs if needed
+        :param base_table: YT table with log records filled by mds-proxy
+        :param aggregate_table: the name of aggregate table
+        """
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+
+        # check for need to run an aggregation query
+        query = self.VALIDATE_QUERY.format(table=aggregate_table, date_iso=yesterday.isoformat())
+        res = self.send_request(query)
+        try:
+            tbl = next(x for x in res.results)
+            row = next(x for x in tbl.rows)
+            count = int(row[0])
+        except:
+            logger.exception("Analysis of validation results has excepted")
+            raise
+
+        if not count:
+            self.prepare_aggregate_table(base_table, aggregate_table, yesterday)
+        else:
+            logger.info("Skip write into aggregation table due to {} records from {}".format(count, str(yesterday)))
+
+    def prepare_aggregate_table(self, base_table, aggregate_table, date):
+        """
+        Update aggregate table from base_table/date
+        :param base_table: YT table with log records filled by mds-proxy
+        :param aggregate_table: the name of aggregate_table (where to store data)
+        :param date: date for which we extract log records that would be added to aggregate_tbale
+        """
+        date_iso = date.isoformat()
+        main_table_per_day = "{}/{}".format(base_table, date_iso)
+
+        query = self.PREAGGREGATE_QUERY.format(agr_table=aggregate_table, main_table=main_table_per_day,
+                                               timestamp=int(time.time()), date_iso=date_iso)
+
+        return self.send_request(query)

--- a/src/mastermind
+++ b/src/mastermind
@@ -2080,7 +2080,8 @@ def ttl_cleanup(iter_group,
         'wait_timeout': wait_timeout,
         'dry_run': dry_run,
         'remove_all_older': remove_all_older,
-        'remove_permanent_older': remove_permament_older
+        'remove_permanent_older': remove_permament_older,
+        'need_approving': True
         }
 
     res = s.enqueue('ttl_cleanup', msgpack.packb(params)).get()


### PR DESCRIPTION
The first approximation of ttl cleanup scheduler. It starts periodically, aggregates data from stat_box of the previous day into YT sub-table. And then based on YT sub-table information and configuration settings, makes a decision whether it worth running mds_cleanup service.

The current solution doesn't analyze the history of runs. And it doesn't take into account inter-crossing between ttl_cleanup on the same HDD. These features are coming