### PR TITLE
Add configurable profiles for mastermind cocaine applications

### DIFF
--- a/debian/mastermind-cocainev11.install
+++ b/debian/mastermind-cocainev11.install
@@ -1,5 +1,6 @@
 usr/bin/mastermind_deploy.sh usr/bin
 usr/bin/mastermind_app_name.sh usr/bin
+usr/bin/mastermind_upload_profile usr/bin
 src/cocaine-app/*.manifest usr/lib/mastermind/cocaine-app/
 src/cocaine-app/*.profile usr/lib/mastermind/cocaine-app/
 mastermind.tar.gz usr/lib/mastermind/cocaine-app/

--- a/examples/mastermind.conf
+++ b/examples/mastermind.conf
@@ -40,6 +40,29 @@
     "forbidden_ns_without_settings": false,
     "forbidden_unmatched_group_total_space": false,
 
+    "cocaine_app_profiles": {
+        "mastermind2.26": {
+            "pool-limit": 5,
+            "spawn-timeout": 120,
+            "heartbeat-timeout": 60,
+            "handshake-timeout": 30
+        },
+
+        "mastermind2.26-cache": {
+            "pool-limit": 1,
+            "spawn-timeout": 120,
+            "heartbeat-timeout": 60,
+            "handshake-timeout": 30
+        },
+
+        "mastermind2.26-inventory": {
+            "pool-limit": 1,
+            "spawn-timeout": 20,
+            "heartbeat-timeout": 40,
+            "handshake-timeout": 5
+        }
+    },
+
     "restore": {
         "rsync_use_module": true,
         "rsync_module": "storage",

--- a/usr/bin/mastermind_deploy.sh
+++ b/usr/bin/mastermind_deploy.sh
@@ -15,4 +15,4 @@ rm -f /var/cache/cocaine/manifests/$APP_NAME
 
 echo "Deploying new application $app"
 cocaine-tool app upload --manifest $DEPLOY_DIR/cocaine-app/$MANIFEST --package $DEPLOY_DIR/cocaine-app/mastermind.tar.gz -n $APP_NAME
-cocaine-tool profile upload -n $APP_NAME --profile $DEPLOY_DIR/cocaine-app/$PROFILE
+/usr/bin/mastermind_upload_profile $APP_NAME --fallback-profile $DEPLOY_DIR/cocaine-app/$PROFILE

--- a/usr/bin/mastermind_upload_profile
+++ b/usr/bin/mastermind_upload_profile
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+import json
+import sys
+import time
+
+import cocaine.tools.actions.profile
+from cocaine.services import Service
+from opster import command
+from tornado.ioloop import IOLoop
+from cocaine.futures import chain
+from cocaine.tools import printer
+
+
+printer.ENABLE_OUTPUT = True
+
+
+CONFIG_PATH = '/etc/elliptics/mastermind.conf'
+
+
+def get_config(config_path):
+    try:
+
+        with open(config_path, 'r') as config_file:
+            return json.load(config_file)
+
+    except Exception as e:
+        raise ValueError('Failed to load config file {}: {}'.format(config_path, e))
+
+
+def upload_profile(service, profile_name, profile_content, timeout=None):
+
+    io_loop = IOLoop.current()
+
+    @chain.source
+    def upload():
+        upload = cocaine.tools.actions.profile.Upload(
+            storage=service,
+            name=profile_name,
+            profile=profile_content,
+        )
+        yield upload.execute()
+
+    @chain.source
+    def execute():
+        try:
+            yield upload()
+        except Exception as e:
+            print 'Error during profile upload: {}'.format(e)
+            sys.exit(1)
+        finally:
+            io_loop.stop()
+
+    def timeout_callback():
+        print "Timeout during profile upload"
+        io_loop.stop()
+        sys.exit(1)
+
+    execute()
+
+    if timeout:
+        io_loop.add_timeout(time.time() + timeout, timeout_callback)
+    io_loop.start()
+
+
+@command()
+def main(profile,
+         timeout=(
+             't',
+             '10',
+             'Upload profile timeout',
+         ),
+         config=(
+             'c',
+             CONFIG_PATH,
+             'Mastermind config',
+         ),
+         fallback_profile=(
+             '',
+             '',
+             'Fallback profile to use if profile is not found in config',
+             None,
+         )):
+    config = get_config(config)
+    profiles_cfg = config.get('cocaine_app_profiles', {})
+
+    if profile in profiles_cfg:
+        profile_content = profiles_cfg[profile]
+    elif fallback_profile:
+        print 'Cocaine application profile "{}" is not found in config, using fallback config'.format(profile)
+        try:
+            profile_content = json.loads(open(fallback_profile, 'rb').read())
+        except Exception as e:
+            raise ValueError('Failed to read fallback profile: {}'.format(e))
+    else:
+        raise ValueError('Cocaine application profile "{}" is not found in config'.format(profile))
+
+    service = Service('storage')
+    upload_profile(
+        service=service,
+        profile_name=profile,
+        profile_content=profile_content,
+        timeout=int(timeout),
+    )
+
+
+if __name__ == '__main__':
+    main.command()


### PR DESCRIPTION
It seems not very convenient to have application profiles
stored as a files since you cannot tweak it to your environment
(testing, dev, etc.). As application profiles are json-s,
they can safely be stored in config which is already different
for different environments.

    Usage example:
    mastermind_upload_profile mastermind2.26
    (this command reads section ['cocaine_app_profiles']['mastermind2.26']
    of config file and uploads it as cocaine profile)