### PR TITLE
Add mimetype namespace settings

### DIFF
--- a/src/cocaine-app/mastermind_core/namespaces/settings/attributes.py
+++ b/src/cocaine-app/mastermind_core/namespaces/settings/attributes.py
@@ -150,11 +150,13 @@ class AttributesSettings(SettingsObject):
     PARENT_KEY = 'attributes'
 
     FILENAME = 'filename'
+    MIMETYPE = 'mimetype'
     TTL = 'ttl'
     SYMLINK = 'symlink'
 
     VALID_SETTING_KEYS = set([
         FILENAME,
+        MIMETYPE,
         TTL,
         SYMLINK,
     ])
@@ -178,6 +180,14 @@ class AttributesSettings(SettingsObject):
     def filename(self, value):
         self._settings[self.FILENAME] = value
 
+    @SettingsObject.settings_property
+    def mimetype(self):
+        return self._settings.get(self.MIMETYPE)
+
+    @mimetype.setter
+    def mimetype(self, value):
+        self._settings[self.MIMETYPE] = value
+
     @property
     def ttl(self):
         return self._ttl
@@ -193,6 +203,14 @@ class AttributesSettings(SettingsObject):
             if not isinstance(self._settings[self.FILENAME], bool):
                 raise ValueError(
                     'Namespace "{}": attributes filename should be boolean'.format(
+                        self.namespace
+                    )
+                )
+
+        if self.MIMETYPE in self._settings:
+            if not isinstance(self._settings[self.MIMETYPE], bool):
+                raise ValueError(
+                    'Namespace "{}": attributes mimetype should be boolean'.format(
                         self.namespace
                     )
                 )

--- a/src/mastermind
+++ b/src/mastermind
@@ -1060,6 +1060,12 @@ def ns_setup(namespace,
                  '',
                  "If this flag is 1, store filename of a key in key's attributes"
              ),
+             attributes_mimetype=(
+                 '',
+                 '',
+                 "This flag toggles the client's ability to store a key's MIME-type in "
+                 "key's attributes."
+             ),
              attributes_ttl=(
                  '',
                  '',
@@ -1156,6 +1162,7 @@ def ns_setup(namespace,
             check_for_update=check_for_update,
             custom_expiration_time=custom_expiration_time == '1',
             attributes_filename=attributes_filename == '1',
+            attributes_mimetype=attributes_mimetype == '1',
             attributes_ttl_minimum=attributes_ttl_minimum,
             attributes_ttl_maximum=attributes_ttl_maximum,
             attributes_symlink_scope_limit=attributes_symlink_scope_limit,
@@ -1257,6 +1264,9 @@ def ns_setup(namespace,
         attributes = {}
         if attributes_filename:
             attributes['filename'] = attributes_filename == '1'
+
+        if attributes_mimetype:
+            attributes['mimetype'] = attributes_mimetype == '1'
 
         ttl_attributes = {}
         if attributes_ttl:

--- a/src/python-mastermind/src/mastermind/query/namespaces.py
+++ b/src/python-mastermind/src/mastermind/query/namespaces.py
@@ -70,6 +70,7 @@ class NamespacesQuery(Query):
               check_for_update=None,
               custom_expiration_time=None,
               attributes_filename=None,
+              attributes_mimetype=None,
               attributes_ttl=None,
               attributes_ttl_minimum=None,
               attributes_ttl_maximum=None,
@@ -116,6 +117,8 @@ class NamespacesQuery(Query):
           custom_expiration_time: allows namespace to use expire-time argument
             for signing url
           attributes_filename: if this flag is True, store filename of a key in key's attributes
+          attributes_mimetype: this flag toggles the client's ability to store a key's
+                MIME-type in key's attributes.
           attributes_ttl: this flag toggles the client's ability to use ttl for keys.
           attributes_ttl_minimum: sets minimum ttl value for namespace's ttl attribute.
             Accepts positive integer values with one of the following postfixes:
@@ -202,6 +205,9 @@ class NamespacesQuery(Query):
         attributes = {}
         if attributes_filename:
             attributes['filename'] = attributes_filename is True
+
+        if attributes_mimetype:
+            attributes['mimetype'] = attributes_mimetype is True
 
         ttl_attributes = {}
         if attributes_ttl is not None:


### PR DESCRIPTION
Mimetype setting enables namespace to use a special key's attribute to store its explicitly specified MIME-type.

When key's json has this attribute set, proxy should consider its value as a key's MIME-type instead of auto-determined one.