### PR TITLE
Add tskv_log name as a config parameter of mastermind (ttl_cleanup section)

### DIFF
--- a/src/cocaine-app/infrastructure.py
+++ b/src/cocaine-app/infrastructure.py
@@ -631,8 +631,8 @@ class Infrastructure(object):
             ),
             safe=('-S' if safe else ''),
             remotes=(' '.join('-r {}'.format(r) for r in remotes)),
-            tskv='--tskv-context namespace={},couple_id={} --tskv-log syslog'.format(
-                couple.namespace, couple.groups[0].group_id
+            tskv='--tskv-context namespace={},couple_id={} --tskv-log {}'.format(
+                couple.namespace, couple.groups[0].group_id, TTL_CLEANUP_CNF.get('tskv_log_file', 'syslog')
             ),
             remove_type=remove_type,
         )


### PR DESCRIPTION
While production uses syslog and only syslog, tests require more flexibility