### PR TITLE
Logging refactoring

### DIFF
--- a/src/cocaine-app/node_info_updater.py
+++ b/src/cocaine-app/node_info_updater.py
@@ -552,7 +552,10 @@ class NodeInfoUpdater(object):
 
             group.parse_meta(meta)
 
-            if group.type == storage.Group.TYPE_UNCOUPLED_LRC_8_2_2_V1:
+            if group.type in (
+                storage.Group.TYPE_UNCOUPLED_LRC_8_2_2_V1,
+                storage.Group.TYPE_RESERVED_LRC_8_2_2_V1,
+            ):
                 return
 
             ns_id = group.meta.get('namespace')

--- a/src/cocaine-app/node_info_updater.py
+++ b/src/cocaine-app/node_info_updater.py
@@ -214,7 +214,7 @@ class NodeInfoUpdater(object):
 
             try:
                 if result['error']:
-                    logger.info(
+                    logger.error(
                         'Monitor stat {node}: request to {url} failed with error {error}'.format(
                             node=node,
                             url=result['url'],
@@ -223,7 +223,7 @@ class NodeInfoUpdater(object):
                     )
                     continue
                 elif result['code'] != 200:
-                    logger.info(
+                    logger.error(
                         'Monitor stat {node}: request to {url} failed with code {code}'.format(
                             node=node,
                             url=result['url'],
@@ -390,7 +390,7 @@ class NodeInfoUpdater(object):
         try:
             node_backend.update_statistics(b_stat, collect_ts)
         except KeyError as e:
-            logger.warn('Bad stat for node backend {0} ({1}): {2}'.format(
+            logger.error('Bad stat for node backend {0} ({1}): {2}'.format(
                 node_backend, e, b_stat))
             pass
 

--- a/src/cocaine-app/storage.py
+++ b/src/cocaine-app/storage.py
@@ -1261,6 +1261,26 @@ class FsStat(object):
         self.commands_stat = sum((nb.stat.commands_stat for nb in node_backends), CommandsStat())
 
 
+def status_change_log(f):
+    @functools.wraps(f)
+    def wrapper(self, *args, **kwargs):
+        prev_status = self.status
+        res = f(self, *args, **kwargs)
+        if prev_status != self.status:
+            logger.info(
+                '{type} {id} status updated from {prev_status} to {cur_status} '
+                '({status_text})'.format(
+                    type=type(self).__name__,
+                    id=self,
+                    prev_status=prev_status,
+                    cur_status=self.status,
+                    status_text=self.status_text,
+                )
+            )
+        return res
+    return wrapper
+
+
 class Fs(object):
     def __init__(self, host, fsid):
         self.host = host
@@ -1288,6 +1308,7 @@ class Fs(object):
     def update_commands_stats(self):
         self.stat.update_commands_stats(self.node_backends)
 
+    @status_change_log
     def update_status(self):
         nbs = self.node_backends.keys()
         prev_status = self.status
@@ -1380,6 +1401,7 @@ class NodeBackend(object):
                                          new_stat['backend']['config'].get('file')) + '/'
         self.stat.update(new_stat, collect_ts)
 
+    @status_change_log
     def update_status(self):
         if not self.stat:
             self.status = Status.INIT
@@ -1683,6 +1705,24 @@ class Group(object):
     def reset_meta(self):
         self.meta = None
 
+    # NOTE: this is custom decorator intended to be used with 'parse_meta()'
+    def __type_change_log(f):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            prev_type = self._type
+            res = f(self, *args, **kwargs)
+            if prev_type != self._type:
+                logger.info(
+                    'Group {id} type updated from {prev_type} to {cur_type}'.format(
+                        id=self,
+                        prev_type=prev_type,
+                        cur_type=self._type,
+                    )
+                )
+            return res
+        return wrapper
+
+    @__type_change_log
     def parse_meta(self, raw_meta):
 
         if raw_meta is None:
@@ -1698,12 +1738,6 @@ class Group(object):
                 raise Exception('Unable to parse meta')
 
         self._type = self._get_type(self.meta)
-        logger.debug(
-            'Group {group}: meta parsed, group type is determined as "{type}"'.format(
-                group=self,
-                type=self._type,
-            )
-        )
 
     def equal_meta(self, other):
         if type(self.meta) != type(other.meta):
@@ -1745,6 +1779,7 @@ class Group(object):
     def effective_free_space(self):
         return sum(nb.effective_free_space for nb in self.node_backends)
 
+    @status_change_log
     def update_status(self):
         """Updates group's own status.
         WARNING: This method should not take into consideration any of the
@@ -1752,7 +1787,7 @@ class Group(object):
         properties, state, etc."""
 
         if not self.node_backends:
-            logger.info('Group {0}: no node backends, status set to INIT'.format(self.group_id))
+            # logger.info('Group {0}: no node backends, status set to INIT'.format(self.group_id))
             self.status = Status.INIT
             self.status_text = ('Group {0} is in INIT state because there is '
                                 'no node backends serving this group'.format(self))
@@ -1941,18 +1976,6 @@ class Group(object):
 
     def __eq__(self, other):
         return self.group_id == other
-
-
-def status_change_log(f):
-    @functools.wraps(f)
-    def wrapper(self, *args, **kwargs):
-        old_status = self.status
-        res = f(self, *args, **kwargs)
-        if old_status != self.status:
-            logger.info('Couple {0} status updated from {1} to {2} ({3})'.format(
-                self, old_status, self.status, self.status_text))
-        return res
-    return wrapper
 
 
 class Groupset(object):

--- a/src/cocaine-app/storage.py
+++ b/src/cocaine-app/storage.py
@@ -1035,12 +1035,12 @@ def _cached(key):
             if footprint != cached_data['footprint']:
 
                 # TODO: Remove this log record
-                logger.debug('Groupset {}, key {}, footprint {}, cached footprint {}'.format(
-                    self,
-                    key,
-                    footprint,
-                    cached_data['footprint'],
-                ))
+                # logger.debug('Groupset {}, key {}, footprint {}, cached footprint {}'.format(
+                #     self,
+                #     key,
+                #     footprint,
+                #     cached_data['footprint'],
+                # ))
                 self._cache[key] = {
                     'data': f(self, *args, **kwargs),
                     'footprint': footprint,


### PR DESCRIPTION
Logging policy changed. Instead of logging all entities' state of every cluster update round only state changes are now logged.