### PR TITLE
Add metadata attributes namespace settings

### DIFF
--- a/src/cocaine-app/mastermind_core/namespaces/settings/attributes.py
+++ b/src/cocaine-app/mastermind_core/namespaces/settings/attributes.py
@@ -145,6 +145,38 @@ class SymlinkSettings(SettingsObject):
             )
 
 
+class MetadataSettings(SettingsObject):
+
+    PARENT_KEY = 'metadata'
+
+    ENABLE = 'enable'
+
+    VALID_SETTING_KEYS = set([
+        ENABLE,
+    ])
+
+    # TODO: Add option to limit total size of custom metadata
+
+    @SettingsObject.settings_property
+    def enable(self):
+        return self._settings.get(self.ENABLE)
+
+    @enable.setter
+    def enable(self, value):
+        self._settings[self.ENABLE] = value
+
+    def validate(self):
+        super(MetadataSettings, self).validate()
+
+        if self.ENABLE in self._settings:
+            if not isinstance(self._settings[self.ENABLE], bool):
+                raise ValueError(
+                    'Namespace "{}": attributes metadata enable should be boolean'.format(
+                        self.namespace
+                    )
+                )
+
+
 class AttributesSettings(SettingsObject):
 
     PARENT_KEY = 'attributes'
@@ -153,12 +185,14 @@ class AttributesSettings(SettingsObject):
     MIMETYPE = 'mimetype'
     TTL = 'ttl'
     SYMLINK = 'symlink'
+    METADATA = 'metadata'
 
     VALID_SETTING_KEYS = set([
         FILENAME,
         MIMETYPE,
         TTL,
         SYMLINK,
+        METADATA,
     ])
 
     def _rebuild(self):
@@ -171,6 +205,11 @@ class AttributesSettings(SettingsObject):
             self._symlink = SymlinkSettings(self, self._settings[self.SYMLINK])
         else:
             self._symlink = SymlinkSettings(self, {})
+
+        if self.METADATA in self._settings:
+            self._metadata = MetadataSettings(self, self._settings[self.METADATA])
+        else:
+            self._metadata = MetadataSettings(self, {})
 
     @SettingsObject.settings_property
     def filename(self):
@@ -196,6 +235,10 @@ class AttributesSettings(SettingsObject):
     def symlink(self):
         return self._symlink
 
+    @property
+    def metadata(self):
+        return self._metadata
+
     def validate(self):
         super(AttributesSettings, self).validate()
 
@@ -217,3 +260,4 @@ class AttributesSettings(SettingsObject):
 
         self._ttl.validate()
         self._symlink.validate()
+        self._metadata.validate()

--- a/src/mastermind
+++ b/src/mastermind
@@ -1099,6 +1099,12 @@ def ns_setup(namespace,
                  'Scope limit for symlink, available values: "namespace" - symlink can be a '
                  'relative url to the same namespace\'s keys;'
              ),
+             attributes_metadata=(
+                 '',
+                 '',
+                 "This flag toggles the client's ability to store key's custom metadata in "
+                 "key's attributes."
+             ),
              json=('', None, 'Format output as json'),
              host=None, app=None):
 
@@ -1175,6 +1181,10 @@ def ns_setup(namespace,
         # symlink should not be passed if not set so that default value stays None
         if attributes_symlink:
             params['attributes_symlink'] = attributes_symlink == '1'
+
+        # metadata should not be passed if not set so that default value stays None
+        if attributes_metadata:
+            params['attributes_metadata'] = attributes_metadata == '1'
 
         ns = cl.namespaces.setup(
             namespace,
@@ -1287,6 +1297,13 @@ def ns_setup(namespace,
 
         if symlink_attributes:
             attributes['symlink'] = symlink_attributes
+
+        metadata_attributes = {}
+        if attributes_metadata:
+            metadata_attributes['enable'] = attributes_metadata == '1'
+
+        if metadata_attributes:
+            attributes['metadata'] = metadata_attributes
 
         if attributes:
             settings['attributes'] = attributes

--- a/src/python-mastermind/src/mastermind/query/namespaces.py
+++ b/src/python-mastermind/src/mastermind/query/namespaces.py
@@ -75,7 +75,8 @@ class NamespacesQuery(Query):
               attributes_ttl_minimum=None,
               attributes_ttl_maximum=None,
               attributes_symlink=None,
-              attributes_symlink_scope_limit=None,):
+              attributes_symlink_scope_limit=None,
+              attributes_metadata=None,):
         """Performs initial namespace setup.
 
         Args:
@@ -138,6 +139,8 @@ class NamespacesQuery(Query):
             (key's data contains url to another key in the scope (see symlink_scope_limit defenition)
           attributes_symlink_scope_limit: scope limit for symlink, available values:
             "namespace": symlink can be a relative url to the same namespace's keys
+          attributes_metadata: this flag toggles the client's ability to store key's custom
+            metadata in key's attributes.
 
         Returns:
           Namespace object representing created namespace.
@@ -228,6 +231,13 @@ class NamespacesQuery(Query):
 
         if symlink_attributes:
             attributes['symlink'] = symlink_attributes
+
+        metadata_attributes = {}
+        if attributes_metadata is not None:
+            metadata_attributes['enable'] = attributes_metadata is True
+
+        if metadata_attributes:
+            attributes['metadata'] = metadata_attributes
 
         if attributes:
             settings['attributes'] = attributes


### PR DESCRIPTION
Metadata attributes setting enables namespace to use a special key's attribute
to store its custom metadata.

When key's json has this attribute set, proxy should consider its value as a set
of key-value pairs that could be used as additional response headers on requests
to the key.