### PR TITLE
Process next job task on the next job process iteration

### DIFF
--- a/src/cocaine-app/jobs/__init__.py
+++ b/src/cocaine-app/jobs/__init__.py
@@ -438,6 +438,11 @@ class JobProcessor(object):
                     job._dirty = True
                     job.update_ts = time.time()
 
+                    if task.status in Task.FINISHED_STATUSES:
+                        # NOTE: this is temporary. Process next task on the next
+                        # job process iteration.
+                        break
+
             if task.status == Task.STATUS_FAILED:
                 job.status = Job.STATUS_PENDING
                 job.on_execution_interrupted()


### PR DESCRIPTION
This is a temporary fix for concurrent processing of a task
in different workers which may lead to task mess.